### PR TITLE
New base image

### DIFF
--- a/.github/workflows/build_container_images.yml
+++ b/.github/workflows/build_container_images.yml
@@ -23,10 +23,9 @@ on:
 
 env:
   build_repo_docker: 'tachidesk'
-  build_base_image_alpine: 'alpine:3.16'
-  build_base_image_alpine_platform: 'linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x'
-  build_base_image_alpine_platform_java11: 'linux/amd64,linux/arm64/v8,linux/ppc64le'
-  build_base_image_alpine_platform_testing: 'linux/amd64'
+  build_base_image_temurin: 'eclipse-temurin:11-jre'
+  build_base_image_temurin_platform: 'linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x'
+  build_base_image_temurin_platform_testing: 'linux/amd64'
   startup_script_url: 'https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/startup_script.sh'
   tachidesk_webui_stable_url: 'https://api.github.com/repos/suwayomi/Tachidesk-Server/releases/latest'
   tachidesk_webui_preview_url: 'https://api.github.com/repos/suwayomi/Tachidesk-Server-preview/releases/latest'
@@ -187,30 +186,29 @@ jobs:
           build_date=$(date "+%F")
           echo "::set-output name=build_date::$build_date"
           echo "::set-output name=repository_owner_lower::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"
-          
-      - name: Build and save stable alpine
-        id: docker_build_release_alpine
+
+      - name: Build and save stable ubuntu
+        id: docker_build_release_ubuntu
         uses: docker/build-push-action@v3
         with:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_alpine_platform_testing }}
+          platforms: ${{ env.build_base_image_temurin_platform_testing }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_alpine }}
+            BASE_IMAGE=${{ env.build_base_image_temurin }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
-            IMAGE_TYPE=stable-alpine
+            IMAGE_TYPE=stable-ubuntu
             TACHIDESK_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.release_commit }}
             TACHIDESK_RELEASE_TAG=${{ steps.get_latest_release_metadata.outputs.release_tag }}
             TACHIDESK_RELEASE_DOWNLOAD_URL=${{ steps.get_latest_release_metadata.outputs.release_url }}
             TACHIDESK_FILENAME=${{ steps.get_latest_release_metadata.outputs.release_filename }}
-            STARTUP_SCRIPT_URL=${{  env.startup_script_url }}
+            STARTUP_SCRIPT_URL=${{ env.startup_script_url }}
             TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
-            JAVA_VERSION=${{  env.java_8_version }}
           tags: |
             test-image:stable
           outputs: type=docker,dest=/tmp/test_image_stable.tar
 
-      - name: Docker Run Test Stable Image
+      - name: Docker Run Test Stable Ubuntu Image
         id: docker_run_test_image_stable
         run: |
             docker load --input /tmp/test_image_stable.tar
@@ -222,30 +220,30 @@ jobs:
             curl -s 127.0.0.1:4568/api/v1/settings/about/ && val=$(curl -s 127.0.0.1:4568/api/v1/settings/about/ | grep -o "Tachidesk" | sort --unique)
             if [[ $val == "Tachidesk" ]]; then
                 echo ""
-                echo "Tachidesk stable run successfully"
+                echo "Tachidesk stable ubuntu run successfully"
                 echo "::set-output name=value::true"
                 docker stop test_image_stable
             else
                 echo ""
-                echo "Tachidesk stable run Failed"
+                echo "Tachidesk stable ubuntu run Failed"
                 echo "::set-output name=value::false"
                 if [[ ${{ needs.check_workflow.outputs.enable_discord_hook }} == 'true' ]]; then
                     curl \
-                      -F 'payload_json={"username": "Github", "content": "<@255018340244914177>\n<@785012853178499073>\nDocker Stable Image Dry Run Failed Version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}' \
+                      -F 'payload_json={"username": "Github", "content": "<@255018340244914177>\n<@785012853178499073>\nDocker Stable Ubuntu Image Dry Run Failed Version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}' \
                       -F "file1=@/home/runner/work/_temp/tachidesk/logfile.log" \
                       "https://discord.com/api/webhooks/${{ secrets.DISCORD_TACHIDESK_WEBHOOK_ID }}/${{ secrets.DISCORD_TACHIDESK_TOKEN }}"
                 fi
                 exit 1
             fi
 
-      - name: Build and save stable alpine java11
-        id: docker_build_release_alpine_java11
+      - name: Build and save stable alpine
+        id: docker_build_release_alpine
         uses: docker/build-push-action@v3
         with:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_alpine_platform_testing }}
+          platforms: ${{ env.build_base_image_temurin_platform_testing }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_alpine }}
+            BASE_IMAGE=${{ env.build_base_image_temurin }}-alpine
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
             IMAGE_TYPE=stable-alpine
@@ -255,34 +253,33 @@ jobs:
             TACHIDESK_FILENAME=${{ steps.get_latest_release_metadata.outputs.release_filename }}
             STARTUP_SCRIPT_URL=${{  env.startup_script_url }}
             TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
-            JAVA_VERSION=${{  env.java_11_version }}
           tags: |
-            test-image:stable-java11
-          outputs: type=docker,dest=/tmp/test_image_stable_java11.tar
+            test-image:stable-alpine
+          outputs: type=docker,dest=/tmp/test_image_stable_alpine.tar
 
-      - name: Docker Run Test Stable Image Java11
-        id: docker_run_test_image_stable_java11
+      - name: Docker Run Test Stable Alpine Image
+        id: docker_run_test_image_stable_alpine
         run: |
-            docker load --input /tmp/test_image_stable_java11.tar
-            mkdir -p /home/runner/work/_temp/tachidesk_java11
-            chmod -R 777 /home/runner/work/_temp/tachidesk_java11
-            docker run --rm -d -p 127.0.0.1:4568:4567 -v /home/runner/work/_temp/tachidesk_java11:/home/suwayomi/.local/share/Tachidesk --name=test_image_stable_java11 test-image:stable-java11
+            docker load --input /tmp/test_image_stable_alpine.tar
+            mkdir -p /home/runner/work/_temp/tachidesk_alpine
+            chmod -R 777 /home/runner/work/_temp/tachidesk_alpine
+            docker run --rm -d -p 127.0.0.1:4568:4567 -v /home/runner/work/_temp/tachidesk_alpine:/home/suwayomi/.local/share/Tachidesk --name=test_image_stable_alpine test-image:stable-alpine
             sleep 15
-            cat /home/runner/work/_temp/tachidesk_java11/logfile.log
+            cat /home/runner/work/_temp/tachidesk_alpine/logfile.log
             curl -s 127.0.0.1:4568/api/v1/settings/about/ && val=$(curl -s 127.0.0.1:4568/api/v1/settings/about/ | grep -o "Tachidesk" | sort --unique)
             if [[ $val == "Tachidesk" ]]; then
                 echo ""
-                echo "Tachidesk stable java11 run successfully"
+                echo "Tachidesk stable alpine run successfully"
                 echo "::set-output name=value::true"
-                docker stop test_image_stable_java11
+                docker stop test_image_stable_alpine
             else
                 echo ""
-                echo "Tachidesk stable run Failed"
+                echo "Tachidesk stable alpine run Failed"
                 echo "::set-output name=value::false"
                 if [[ ${{ needs.check_workflow.outputs.enable_discord_hook }} == 'true' ]]; then
                     curl \
-                      -F 'payload_json={"username": "Github", "content": "<@255018340244914177>\n<@785012853178499073>\nDocker Stable Java11 Image Dry Run Failed Version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}' \
-                      -F "file1=@/home/runner/work/_temp/tachidesk/logfile.log" \
+                      -F 'payload_json={"username": "Github", "content": "<@255018340244914177>\n<@785012853178499073>\nDocker Stable Alpine Image Dry Run Failed Version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}' \
+                      -F "file1=@/home/runner/work/_temp/tachidesk_alpine/logfile.log" \
                       "https://discord.com/api/webhooks/${{ secrets.DISCORD_TACHIDESK_WEBHOOK_ID }}/${{ secrets.DISCORD_TACHIDESK_TOKEN }}"
                 fi
                 exit 1
@@ -291,7 +288,9 @@ jobs:
       - name: Delete docker files
         run: |
           rm -f /tmp/test_image_stable.tar
+          rm -f /tmp/test_image_stable_alpine.tar
           #rm -rf /home/runner/work/_temp/tachidesk
+          #rm -rf /home/runner/work/_temp/tachidesk_alpine
           
 
   build_stable:
@@ -321,15 +320,42 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
           
+      - name: Build and push stable ubuntu
+        id: docker_build_release_ubuntu
+        uses: docker/build-push-action@v3
+        with:
+          file: scripts/dockerfiles/Git_Actions-Dockerfile
+          platforms: ${{ env.build_base_image_temurin_platform }}
+          push: ${{ needs.check_stable.outputs.enable_build_publish == 'true' }}
+          build-args: |
+            BASE_IMAGE=${{ env.build_base_image_temurin }}
+            BUILD_DATE=${{ needs.check_stable.outputs.build_date }}
+            IMAGE_VERSION=${{ needs.check_stable.outputs.release_version }}
+            IMAGE_TYPE=stable-ubuntu
+            TACHIDESK_GIT_COMMIT=${{ needs.check_stable.outputs.release_commit }}
+            TACHIDESK_RELEASE_TAG=${{ needs.check_stable.outputs.release_tag }}
+            TACHIDESK_RELEASE_DOWNLOAD_URL=${{ needs.check_stable.outputs.release_url }}
+            TACHIDESK_FILENAME=${{ needs.check_stable.outputs.release_filename }}
+            STARTUP_SCRIPT_URL=${{  env.startup_script_url }}
+            TACHIDESK_DOCKER_GIT_COMMIT=${{ needs.check_stable.outputs.tachidesk_docker_git_commit }}
+            IMAGE_OWNER=${{ needs.check_stable.outputs.repository_owner_lower }}
+          tags: |
+            ghcr.io/${{ needs.check_stable.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:latest
+            ghcr.io/${{ needs.check_stable.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:${{ needs.check_stable.outputs.release_tag }}
+            ghcr.io/${{ needs.check_stable.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:latest-ubuntu
+            ghcr.io/${{ needs.check_stable.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:${{ needs.check_stable.outputs.release_tag }}-ubuntu
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
       - name: Build and push stable alpine
         id: docker_build_release_alpine
         uses: docker/build-push-action@v3
         with:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_alpine_platform }}
+          platforms: ${{ env.build_base_image_temurin_platform }}
           push: ${{ needs.check_stable.outputs.enable_build_publish == 'true' }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_alpine }}
+            BASE_IMAGE=${{ env.build_base_image_temurin }}-alpine
             BUILD_DATE=${{ needs.check_stable.outputs.build_date }}
             IMAGE_VERSION=${{ needs.check_stable.outputs.release_version }}
             IMAGE_TYPE=stable-alpine
@@ -340,36 +366,9 @@ jobs:
             STARTUP_SCRIPT_URL=${{  env.startup_script_url }}
             TACHIDESK_DOCKER_GIT_COMMIT=${{ needs.check_stable.outputs.tachidesk_docker_git_commit }}
             IMAGE_OWNER=${{ needs.check_stable.outputs.repository_owner_lower }}
-            JAVA_VERSION=${{  env.java_8_version }}
           tags: |
-            ghcr.io/${{ needs.check_stable.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:latest
-            ghcr.io/${{ needs.check_stable.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:${{ needs.check_stable.outputs.release_tag }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-
-      - name: Build and push stable alpine java11
-        id: docker_build_release_alpine_java11
-        uses: docker/build-push-action@v3
-        with:
-          file: scripts/dockerfiles/Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_alpine_platform_java11 }}
-          push: ${{ needs.check_stable.outputs.enable_build_publish == 'true' }}
-          build-args: |
-            BASE_IMAGE=${{ env.build_base_image_alpine }}
-            BUILD_DATE=${{ needs.check_stable.outputs.build_date }}
-            IMAGE_VERSION=${{ needs.check_stable.outputs.release_version }}
-            IMAGE_TYPE=stable-alpine
-            TACHIDESK_GIT_COMMIT=${{ needs.check_stable.outputs.release_commit }}
-            TACHIDESK_RELEASE_TAG=${{ needs.check_stable.outputs.release_tag }}
-            TACHIDESK_RELEASE_DOWNLOAD_URL=${{ needs.check_stable.outputs.release_url }}
-            TACHIDESK_FILENAME=${{ needs.check_stable.outputs.release_filename }}
-            STARTUP_SCRIPT_URL=${{  env.startup_script_url }}
-            TACHIDESK_DOCKER_GIT_COMMIT=${{ needs.check_stable.outputs.tachidesk_docker_git_commit }}
-            IMAGE_OWNER=${{ needs.check_stable.outputs.repository_owner_lower }}
-            JAVA_VERSION=${{  env.java_11_version }}
-          tags: |
-            ghcr.io/${{ needs.check_stable.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:latest-java11
-            ghcr.io/${{ needs.check_stable.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:${{ needs.check_stable.outputs.release_tag }}-java11
+            ghcr.io/${{ needs.check_stable.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:latest-alpine
+            ghcr.io/${{ needs.check_stable.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:${{ needs.check_stable.outputs.release_tag }}-alpine
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -452,29 +451,28 @@ jobs:
           echo "::set-output name=build_date::$build_date"
           echo "::set-output name=repository_owner_lower::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"          
           
-      - name: Build and save preview alpine
-        id: docker_build_release_alpine
+      - name: Build and save preview ubuntu
+        id: docker_build_release_ubuntu
         uses: docker/build-push-action@v3
         with:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_alpine_platform_testing }}
+          platforms: ${{ env.build_base_image_temurin_platform_testing }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_alpine }}
+            BASE_IMAGE=${{ env.build_base_image_temurin }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
-            IMAGE_TYPE=preview-alpine
+            IMAGE_TYPE=preview-ubuntu
             TACHIDESK_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.release_commit }}
             TACHIDESK_RELEASE_TAG=${{ steps.get_latest_release_metadata.outputs.release_tag }}
             TACHIDESK_RELEASE_DOWNLOAD_URL=${{ steps.get_latest_release_metadata.outputs.release_url }}
             TACHIDESK_FILENAME=${{ steps.get_latest_release_metadata.outputs.release_filename }}
             STARTUP_SCRIPT_URL=${{ env.startup_script_url }}
             TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
-            JAVA_VERSION=${{  env.java_8_version }}
           tags: |
             test-image:preview
           outputs: type=docker,dest=/tmp/test_image_preview.tar
           
-      - name: Docker Run Test Preview Image
+      - name: Docker Run Test Preview Image Ubuntu
         id: docker_run_test_image_preview
         run: |
             docker load --input /tmp/test_image_preview.tar
@@ -504,14 +502,14 @@ jobs:
             fi            
             docker system prune -a -f --volumes
 
-      - name: Build and save preview alpine java11
-        id: docker_build_release_alpine_java11
+      - name: Build and save preview alpine
+        id: docker_build_release_alpine
         uses: docker/build-push-action@v3
         with:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_alpine_platform_testing }}
+          platforms: ${{ env.build_base_image_temurin_platform_testing }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_alpine }}
+            BASE_IMAGE=${{ env.build_base_image_temurin }}-alpine
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
             IMAGE_TYPE=preview-alpine
@@ -521,36 +519,35 @@ jobs:
             TACHIDESK_FILENAME=${{ steps.get_latest_release_metadata.outputs.release_filename }}
             STARTUP_SCRIPT_URL=${{ env.startup_script_url }}
             TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
-            JAVA_VERSION=${{  env.java_11_version }}
           tags: |
-            test-image:preview-java11
-          outputs: type=docker,dest=/tmp/test_image_preview_java11.tar
+            test-image:preview-alpine
+          outputs: type=docker,dest=/tmp/test_image_preview_alpine.tar
 
           
-      - name: Docker Run Test Preview Image Java11
-        id: docker_run_test_image_preview_java11
+      - name: Docker Run Test Preview Image Alpine
+        id: docker_run_test_image_preview_alpine
         run: |
-            docker load --input /tmp/test_image_preview_java11.tar
-            mkdir -p /home/runner/work/_temp/tachidesk_java11
-            chmod -R 777 /home/runner/work/_temp/tachidesk_java11
-            docker run --rm -d -p 127.0.0.1:4569:4567 -v /home/runner/work/_temp/tachidesk_java11:/home/suwayomi/.local/share/Tachidesk  --name=test_image_preview_java11 test-image:preview-java11
+            docker load --input /tmp/test_image_preview_alpine.tar
+            mkdir -p /home/runner/work/_temp/tachidesk_alpine
+            chmod -R 777 /home/runner/work/_temp/tachidesk_alpine
+            docker run --rm -d -p 127.0.0.1:4569:4567 -v /home/runner/work/_temp/tachidesk_alpine:/home/suwayomi/.local/share/Tachidesk  --name=test_image_preview_alpine test-image:preview-alpine
             sleep 15
-            cat /home/runner/work/_temp/tachidesk/logfile.log
+            cat /home/runner/work/_temp/tachidesk_alpine/logfile.log
             curl -s 127.0.0.1:4569/api/v1/settings/about/ && val=$(curl -s 127.0.0.1:4569/api/v1/settings/about/ | grep -o "Tachidesk" | sort --unique)
             if [[ $val == "Tachidesk" ]]; then
                 echo ""
-                echo "Tachidesk preview java11 run successfully"
+                echo "Tachidesk preview alpine run successfully"
                 echo "::set-output name=value::true"
-                docker stop test_image_preview_java11
+                docker stop test_image_preview_alpine
                 run_check="true"
             else
                 echo ""
-                echo "Tachidesk preview java11 run Failed"
+                echo "Tachidesk preview alpine run Failed"
                 echo "::set-output name=value::false"
                 if [[ ${{ needs.check_workflow.outputs.enable_discord_hook }} == 'true' ]]; then                
                     curl \
-                      -F 'payload_json={"username": "Github", "content": "<@255018340244914177>\n<@785012853178499073>\nDocker Preview Java11 Image Dry Run Failed Version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}' \
-                      -F "file1=@/home/runner/work/_temp/tachidesk/logfile.log" \
+                      -F 'payload_json={"username": "Github", "content": "<@255018340244914177>\n<@785012853178499073>\nDocker Preview Alpine Image Dry Run Failed Version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}' \
+                      -F "file1=@/home/runner/work/_temp/tachidesk_alpine/logfile.log" \
                       "https://discord.com/api/webhooks/${{ secrets.DISCORD_TACHIDESK_WEBHOOK_ID }}/${{ secrets.DISCORD_TACHIDESK_TOKEN }}"
                 fi
                 exit 1
@@ -560,7 +557,9 @@ jobs:
       - name: Delete docker files
         run: |
           rm -f /tmp/test_image_preview.tar
+          rm -f /tmp/test_image_preview_alpine.tar
           #rm -rf /home/runner/work/_temp/tachidesk
+          #rm -rf /home/runner/work/_temp/tachidesk_alpine
 
   build_preview:
     needs: check_preview
@@ -589,15 +588,40 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
   
+      - name: Build and push preview ubuntu
+        id: docker_build_release_ubuntu
+        uses: docker/build-push-action@v3
+        with:
+          file: scripts/dockerfiles/Git_Actions-Dockerfile
+          platforms: ${{ env.build_base_image_temurin_platform }}
+          push: ${{ needs.check_preview.outputs.enable_build_publish == 'true' }}
+          build-args: |
+            BASE_IMAGE=${{ env.build_base_image_temurin }}
+            BUILD_DATE=${{ needs.check_preview.outputs.build_date }}
+            IMAGE_VERSION=${{ needs.check_preview.outputs.release_version }}
+            IMAGE_TYPE=preview-ubuntu
+            TACHIDESK_GIT_COMMIT=${{ needs.check_preview.outputs.release_commit }}
+            TACHIDESK_RELEASE_TAG=${{ needs.check_preview.outputs.release_tag }}
+            TACHIDESK_RELEASE_DOWNLOAD_URL=${{ needs.check_preview.outputs.release_url }}
+            TACHIDESK_FILENAME=${{ needs.check_preview.outputs.release_filename }}
+            STARTUP_SCRIPT_URL=${{ env.startup_script_url }}
+            TACHIDESK_DOCKER_GIT_COMMIT=${{ needs.check_preview.outputs.tachidesk_docker_git_commit }}
+            IMAGE_OWNER=${{ needs.check_preview.outputs.repository_owner_lower }}          
+          tags: |
+            ghcr.io/${{ needs.check_preview.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:preview
+            ghcr.io/${{ needs.check_preview.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:preview-ubuntu
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
       - name: Build and push preview alpine
         id: docker_build_release_alpine
         uses: docker/build-push-action@v3
         with:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_alpine_platform }}
+          platforms: ${{ env.build_base_image_temurin_platform }}
           push: ${{ needs.check_preview.outputs.enable_build_publish == 'true' }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_alpine }}
+            BASE_IMAGE=${{ env.build_base_image_temurin }}-alpine
             BUILD_DATE=${{ needs.check_preview.outputs.build_date }}
             IMAGE_VERSION=${{ needs.check_preview.outputs.release_version }}
             IMAGE_TYPE=preview-alpine
@@ -608,34 +632,8 @@ jobs:
             STARTUP_SCRIPT_URL=${{ env.startup_script_url }}
             TACHIDESK_DOCKER_GIT_COMMIT=${{ needs.check_preview.outputs.tachidesk_docker_git_commit }}
             IMAGE_OWNER=${{ needs.check_preview.outputs.repository_owner_lower }}          
-            JAVA_VERSION=${{  env.java_8_version }}  
           tags: |
-            ghcr.io/${{ needs.check_preview.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:preview
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-
-      - name: Build and push preview alpine java11
-        id: docker_build_release_alpine_java11
-        uses: docker/build-push-action@v3
-        with:
-          file: scripts/dockerfiles/Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_alpine_platform_java11 }}
-          push: ${{ needs.check_preview.outputs.enable_build_publish == 'true' }}
-          build-args: |
-            BASE_IMAGE=${{ env.build_base_image_alpine }}
-            BUILD_DATE=${{ needs.check_preview.outputs.build_date }}
-            IMAGE_VERSION=${{ needs.check_preview.outputs.release_version }}
-            IMAGE_TYPE=preview-alpine
-            TACHIDESK_GIT_COMMIT=${{ needs.check_preview.outputs.release_commit }}
-            TACHIDESK_RELEASE_TAG=${{ needs.check_preview.outputs.release_tag }}
-            TACHIDESK_RELEASE_DOWNLOAD_URL=${{ needs.check_preview.outputs.release_url }}
-            TACHIDESK_FILENAME=${{ needs.check_preview.outputs.release_filename }}
-            STARTUP_SCRIPT_URL=${{ env.startup_script_url }}
-            TACHIDESK_DOCKER_GIT_COMMIT=${{ needs.check_preview.outputs.tachidesk_docker_git_commit }}
-            IMAGE_OWNER=${{ needs.check_preview.outputs.repository_owner_lower }}          
-            JAVA_VERSION=${{  env.java_11_version }}  
-          tags: |
-            ghcr.io/${{ needs.check_preview.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:preview-java11
+            ghcr.io/${{ needs.check_preview.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:preview-alpine
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 

--- a/.github/workflows/build_container_images.yml
+++ b/.github/workflows/build_container_images.yml
@@ -52,84 +52,84 @@ jobs:
             if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then           
                 if [[ "${{ github.event.inputs.tachidesk_release_type }}" == "stable" ]]; then 
                     if [[ "${{ github.actor }}"  == "AriaMoradi" ]]; then         
-                        echo "::set-output name=run_check_stable::true"
-                        echo "::set-output name=run_build_stable::true"   
-                        echo "::set-output name=enable_build_publish::true"
-                        echo "::set-output name=enable_discord_hook::true"
+                        echo "run_check_stable=true" >> $GITHUB_OUTPUT
+                        echo "run_build_stable=true" >> $GITHUB_OUTPUT  
+                        echo "enable_build_publish=true" >> $GITHUB_OUTPUT
+                        echo "enable_discord_hook=true" >> $GITHUB_OUTPUT
                     elif [[ "${{ github.actor }}"  == "arbuilder" && "${{ github.repository_owner }}" == "arbuilder" ]]; then
-                        echo "::set-output name=run_check_stable::true"
-                        echo "::set-output name=run_build_stable::true"   
-                        echo "::set-output name=enable_build_publish::true"
-                        echo "::set-output name=enable_discord_hook::true"
+                        echo "run_check_stable=true" >> $GITHUB_OUTPUT
+                        echo "run_build_stable=true" >> $GITHUB_OUTPUT
+                        echo "enable_build_publish=true" >> $GITHUB_OUTPUT
+                        echo "enable_discord_hook=true" >> $GITHUB_OUTPUT
                     elif [[ "${{ github.actor }}"  == "arbuilder" && "${{ github.repository_owner }}" == "Suwayomi" && "${{ github.event.inputs.publish_images_manually }}" == "yes"  ]]; then
-                        echo "::set-output name=run_check_stable::true"
-                        echo "::set-output name=run_build_stable::true"   
-                        echo "::set-output name=enable_build_publish::true"
-                        echo "::set-output name=enable_discord_hook::true"
+                        echo "run_check_stable=true" >> $GITHUB_OUTPUT
+                        echo "run_build_stable=true" >> $GITHUB_OUTPUT   
+                        echo "enable_build_publish=true" >> $GITHUB_OUTPUT
+                        echo "enable_discord_hook=true" >> $GITHUB_OUTPUT
                     elif [[ "${{ github.actor }}"  == "arbuilder" && "${{ github.repository_owner }}" == "Suwayomi" && "${{ github.event.inputs.publish_images_manually }}" == "no" ]]; then
-                        echo "::set-output name=run_check_stable::true"
-                        echo "::set-output name=run_build_stable::true"   
-                        echo "::set-output name=enable_build_publish::false"
-                        echo "::set-output name=enable_discord_hook::false"
+                        echo "run_check_stable=true" >> $GITHUB_OUTPUT
+                        echo "run_build_stable=true" >> $GITHUB_OUTPUT   
+                        echo "enable_build_publish=false" >> $GITHUB_OUTPUT
+                        echo "enable_discord_hook=false" >> $GITHUB_OUTPUT
                     elif [[ "${{ github.actor }}"  != "arbuilder" && "${{ github.event.inputs.publish_images_manually }}" == "yes" ]]; then
-                        echo "::set-output name=run_check_stable::true"
-                        echo "::set-output name=run_build_stable::true"   
-                        echo "::set-output name=enable_build_publish::true"
-                        echo "::set-output name=enable_discord_hook::false"
+                        echo "run_check_stable=true" >> $GITHUB_OUTPUT
+                        echo "run_build_stable=true" >> $GITHUB_OUTPUT   
+                        echo "enable_build_publish=true" >> $GITHUB_OUTPUT
+                        echo "enable_discord_hook=false" >> $GITHUB_OUTPUT
                     else
-                        echo "::set-output name=run_check_stable::false"
-                        echo "::set-output name=run_build_stable::false"   
-                        echo "::set-output name=enable_build_publish::false"
-                        echo "::set-output name=enable_discord_hook::false"
+                        echo "run_check_stable=false" >> $GITHUB_OUTPUT
+                        echo "run_build_stable=false" >> $GITHUB_OUTPUT   
+                        echo "enable_build_publish=false" >> $GITHUB_OUTPUT
+                        echo "enable_discord_hook=false" >> $GITHUB_OUTPUT
                     fi
                 fi
                 if [[ "${{ github.event.inputs.tachidesk_release_type }}" == "preview" ]]; then
                     if [[ "${{ github.actor }}"  == "AriaMoradi" ]]; then         
-                        echo "::set-output name=run_check_preview::true"
-                        echo "::set-output name=run_build_preview::true"   
-                        echo "::set-output name=enable_build_publish::true"
-                        echo "::set-output name=enable_discord_hook::true"
+                        echo "run_check_preview=true" >> $GITHUB_OUTPUT
+                        echo "run_build_preview=true" >> $GITHUB_OUTPUT  
+                        echo "enable_build_publish=true" >> $GITHUB_OUTPUT
+                        echo "enable_discord_hook=true" >> $GITHUB_OUTPUT
                     elif [[ "${{ github.actor }}"  == "arbuilder" && "${{ github.repository_owner }}" == "arbuilder" ]]; then
-                        echo "::set-output name=run_check_preview::true"
-                        echo "::set-output name=run_build_preview::true"   
-                        echo "::set-output name=enable_build_publish::true"
-                        echo "::set-output name=enable_discord_hook::true"
+                        echo "run_check_preview=true" >> $GITHUB_OUTPUT
+                        echo "run_build_preview=true" >> $GITHUB_OUTPUT  
+                        echo "enable_build_publish=true" >> $GITHUB_OUTPUT
+                        echo "enable_discord_hook=true" >> $GITHUB_OUTPUT
                     elif [[ "${{ github.actor }}"  == "arbuilder" && "${{ github.repository_owner }}" == "Suwayomi" && "${{ github.event.inputs.publish_images_manually }}" == "yes" ]]; then
-                        echo "::set-output name=run_check_preview::true"
-                        echo "::set-output name=run_build_preview::true"   
-                        echo "::set-output name=enable_build_publish::true"
-                        echo "::set-output name=enable_discord_hook::true"
+                        echo "run_check_preview=true" >> $GITHUB_OUTPUT
+                        echo "run_build_preview=true" >> $GITHUB_OUTPUT   
+                        echo "enable_build_publish=true" >> $GITHUB_OUTPUT
+                        echo "enable_discord_hook=true" >> $GITHUB_OUTPUT
                     elif [[ "${{ github.actor }}"  == "arbuilder" && "${{ github.repository_owner }}" == "Suwayomi" && "${{ github.event.inputs.publish_images_manually }}" == "no" ]]; then
-                        echo "::set-output name=run_check_preview::true"
-                        echo "::set-output name=run_build_preview::true"   
-                        echo "::set-output name=enable_build_publish::false"
-                        echo "::set-output name=enable_discord_hook::false"
+                        echo "run_check_preview=true" >> $GITHUB_OUTPUT
+                        echo "run_build_preview=true" >> $GITHUB_OUTPUT  
+                        echo "enable_build_publish=false" >> $GITHUB_OUTPUT
+                        echo "enable_discord_hook=false" >> $GITHUB_OUTPUT
                     elif [[ "${{ github.actor }}"  != "arbuilder" && "${{ github.event.inputs.publish_images_manually }}" == "yes" ]]; then
-                        echo "::set-output name=run_check_preview::true"
-                        echo "::set-output name=run_build_preview::true"   
-                        echo "::set-output name=enable_build_publish::true"
-                        echo "::set-output name=enable_discord_hook::false"
+                        echo "run_check_preview=true" >> $GITHUB_OUTPUT
+                        echo "run_build_preview=true" >> $GITHUB_OUTPUT   
+                        echo "enable_build_publish=true" >> $GITHUB_OUTPUT
+                        echo "enable_discord_hook=false" >> $GITHUB_OUTPUT
                     else
-                        echo "::set-output name=run_check_preview::false"
-                        echo "::set-output name=run_build_preview::false"   
-                        echo "::set-output name=enable_build_publish::false"
-                        echo "::set-output name=enable_discord_hook::false"
+                        echo "run_check_preview=false" >> $GITHUB_OUTPUT
+                        echo "run_build_preview=false" >> $GITHUB_OUTPUT   
+                        echo "enable_build_publish=false" >> $GITHUB_OUTPUT
+                        echo "enable_discord_hook=false" >> $GITHUB_OUTPUT
                     fi
                 fi
             elif [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "push" ]]; then
-                echo "::set-output name=run_check_stable::true"
-                echo "::set-output name=run_build_stable::false"                 
-                echo "::set-output name=run_check_preview::false"                
-                echo "::set-output name=run_build_preview::false"
-                echo "::set-output name=enable_build_publish::false"
-                echo "::set-output name=enable_discord_hook::false"
+                echo "run_check_stable=true" >> $GITHUB_OUTPUT
+                echo "run_build_stable=false" >> $GITHUB_OUTPUT                 
+                echo "run_check_preview=false" >> $GITHUB_OUTPUT               
+                echo "run_build_preview=false" >> $GITHUB_OUTPUT
+                echo "enable_build_publish=false" >> $GITHUB_OUTPUT
+                echo "enable_discord_hook=false" >> $GITHUB_OUTPUT
             else
-                echo "::set-output name=run_check_stable::false"
-                echo "::set-output name=run_build_stable::false" 
-                echo "::set-output name=run_check_preview::false"
-                echo "::set-output name=run_build_preview::false"   
-                echo "::set-output name=enable_build_publish::false"
-                echo "::set-output name=enable_discord_hook::false"
+                echo "run_check_stable=false" >> $GITHUB_OUTPUT
+                echo "run_build_stable=false" >> $GITHUB_OUTPUT
+                echo "run_check_preview=false" >> $GITHUB_OUTPUT
+                echo "run_build_preview=false" >> $GITHUB_OUTPUT  
+                echo "enable_build_publish=false" >> $GITHUB_OUTPUT
+                echo "enable_discord_hook=false" >> $GITHUB_OUTPUT
             fi
             
   check_stable:
@@ -176,17 +176,17 @@ jobs:
           release_commit=$(echo $release_var | cut -f2 -d"r")
           release_filename=Tachidesk-Server-${release_var}.jar
           release_version=$(echo $release_tag | cut -c2-)
-          echo "::set-output name=release_url::$release_url"
-          echo "::set-output name=release_commit::$release_commit"
-          echo "::set-output name=release_tag::$release_tag"
-          echo "::set-output name=release_filename::$release_filename"
-          echo "::set-output name=release_version::$release_version"
-          echo "::set-output name=release_var::$release_var"
+          echo "release_url=$release_url" >> $GITHUB_OUTPUT
+          echo "release_commit=$release_commit" >> $GITHUB_OUTPUT
+          echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
+          echo "release_filename=$release_filename" >> $GITHUB_OUTPUT
+          echo "release_version=$release_version" >> $GITHUB_OUTPUT
+          echo "release_var=$release_var" >> $GITHUB_OUTPUT
           tachidesk_docker_git_commit=$(git rev-list --count HEAD)
-          echo "::set-output name=tachidesk_docker_git_commit::$tachidesk_docker_git_commit"
+          echo "tachidesk_docker_git_commit=$tachidesk_docker_git_commit" >> $GITHUB_OUTPUT
           build_date=$(date "+%F")
-          echo "::set-output name=build_date::$build_date"
-          echo "::set-output name=repository_owner_lower::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"
+          echo "build_date=$build_date" >> $GITHUB_OUTPUT
+          echo "repository_owner_lower=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Build and save stable ubuntu
         id: docker_build_release_ubuntu
@@ -222,12 +222,12 @@ jobs:
             if [[ $val == "Tachidesk" ]]; then
                 echo ""
                 echo "Tachidesk stable ubuntu run successfully"
-                echo "::set-output name=value::true"
+                echo "value=true" >> $GITHUB_OUTPUT
                 docker stop test_image_stable
             else
                 echo ""
                 echo "Tachidesk stable ubuntu run Failed"
-                echo "::set-output name=value::false"
+                echo "value=false" >> $GITHUB_OUTPUT
                 if [[ ${{ needs.check_workflow.outputs.enable_discord_hook }} == 'true' ]]; then
                     curl \
                       -F 'payload_json={"username": "Github", "content": "<@255018340244914177>\n<@785012853178499073>\nDocker Stable Ubuntu Image Dry Run Failed Version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}' \
@@ -271,12 +271,12 @@ jobs:
             if [[ $val == "Tachidesk" ]]; then
                 echo ""
                 echo "Tachidesk stable alpine run successfully"
-                echo "::set-output name=value::true"
+                echo "value=true" >> $GITHUB_OUTPUT
                 docker stop test_image_stable_alpine
             else
                 echo ""
                 echo "Tachidesk stable alpine run Failed"
-                echo "::set-output name=value::false"
+                echo "value=false" >> $GITHUB_OUTPUT
                 if [[ ${{ needs.check_workflow.outputs.enable_discord_hook }} == 'true' ]]; then
                     curl \
                       -F 'payload_json={"username": "Github", "content": "<@255018340244914177>\n<@785012853178499073>\nDocker Stable Alpine Image Dry Run Failed Version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}' \
@@ -440,17 +440,17 @@ jobs:
           release_commit=$(echo $release_var | cut -f2 -d"r")
           release_filename=Tachidesk-Server-${release_var}.jar
           release_version=$(echo $release_tag | cut -c2-)
-          echo "::set-output name=release_url::$release_url"
-          echo "::set-output name=release_commit::$release_commit"
-          echo "::set-output name=release_tag::$release_tag"
-          echo "::set-output name=release_filename::$release_filename"
-          echo "::set-output name=release_version::$release_version"
-          echo "::set-output name=release_var::$release_var"
+          echo "release_url=$release_url" >> $GITHUB_OUTPUT
+          echo "release_commit=$release_commit" >> $GITHUB_OUTPUT
+          echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
+          echo "release_filename=$release_filename" >> $GITHUB_OUTPUT
+          echo "release_version=$release_version" >> $GITHUB_OUTPUT
+          echo "release_var=$release_var" >> $GITHUB_OUTPUT
           tachidesk_docker_git_commit=$(git rev-list --count HEAD)
-          echo "::set-output name=tachidesk_docker_git_commit::$tachidesk_docker_git_commit"
+          echo "tachidesk_docker_git_commit=$tachidesk_docker_git_commit" >> $GITHUB_OUTPUT
           build_date=$(date "+%F")
-          echo "::set-output name=build_date::$build_date"
-          echo "::set-output name=repository_owner_lower::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"          
+          echo "build_date=$build_date" >> $GITHUB_OUTPUT
+          echo "repository_owner_lower=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT         
           
       - name: Build and save preview ubuntu
         id: docker_build_release_ubuntu
@@ -486,13 +486,13 @@ jobs:
             if [[ $val == "Tachidesk" ]]; then
                 echo ""
                 echo "Tachidesk preview run successfully"
-                echo "::set-output name=value::true"
+                echo "value=true" >> $GITHUB_OUTPUT
                 docker stop test_image_preview
                 run_check="true"
             else
                 echo ""
                 echo "Tachidesk preview run Failed"
-                echo "::set-output name=value::false"
+                echo "value=false" >> $GITHUB_OUTPUT
                 if [[ ${{ needs.check_workflow.outputs.enable_discord_hook }} == 'true' ]]; then                
                     curl \
                       -F 'payload_json={"username": "Github", "content": "<@255018340244914177>\n<@785012853178499073>\nDocker Preview Image Dry Run Failed Version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}' \
@@ -538,13 +538,13 @@ jobs:
             if [[ $val == "Tachidesk" ]]; then
                 echo ""
                 echo "Tachidesk preview alpine run successfully"
-                echo "::set-output name=value::true"
+                echo "value=true" >> $GITHUB_OUTPUT
                 docker stop test_image_preview_alpine
                 run_check="true"
             else
                 echo ""
                 echo "Tachidesk preview alpine run Failed"
-                echo "::set-output name=value::false"
+                echo "value=false" >> $GITHUB_OUTPUT
                 if [[ ${{ needs.check_workflow.outputs.enable_discord_hook }} == 'true' ]]; then                
                     curl \
                       -F 'payload_json={"username": "Github", "content": "<@255018340244914177>\n<@785012853178499073>\nDocker Preview Alpine Image Dry Run Failed Version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}' \

--- a/.github/workflows/build_container_images.yml
+++ b/.github/workflows/build_container_images.yml
@@ -23,7 +23,7 @@ on:
 
 env:
   build_repo_docker: 'tachidesk'
-  build_base_image_temurin_ubuntu: 'eclipse-temurin:11-jre-focal'
+  build_base_image_temurin_ubuntu: 'eclipse-temurin:11-jre-jammy'
   build_base_image_temurin_alpine: 'eclipse-temurin:11-jre-alpine'
   build_base_image_temurin_platform: 'linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x'
   build_base_image_temurin_platform_testing: 'linux/amd64'

--- a/.github/workflows/build_container_images.yml
+++ b/.github/workflows/build_container_images.yml
@@ -25,7 +25,7 @@ env:
   build_repo_docker: 'tachidesk'
   build_base_image_temurin_ubuntu: 'eclipse-temurin:11-jre-focal'
   build_base_image_temurin_alpine: 'eclipse-temurin:11-jre-alpine'
-  build_base_image_temurin_platform: 'linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x'
+  build_base_image_temurin_platform: 'linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x'
   build_base_image_temurin_platform_testing: 'linux/amd64'
   startup_script_url: 'https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/startup_script.sh'
   tachidesk_webui_stable_url: 'https://api.github.com/repos/suwayomi/Tachidesk-Server/releases/latest'

--- a/.github/workflows/build_container_images.yml
+++ b/.github/workflows/build_container_images.yml
@@ -23,7 +23,8 @@ on:
 
 env:
   build_repo_docker: 'tachidesk'
-  build_base_image_temurin: 'eclipse-temurin:11-jre'
+  build_base_image_temurin_ubuntu: 'eclipse-temurin:11-jre-focal'
+  build_base_image_temurin_alpine: 'eclipse-temurin:11-jre-alpine'
   build_base_image_temurin_platform: 'linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x'
   build_base_image_temurin_platform_testing: 'linux/amd64'
   startup_script_url: 'https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/startup_script.sh'
@@ -194,7 +195,7 @@ jobs:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
           platforms: ${{ env.build_base_image_temurin_platform_testing }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin }}
+            BASE_IMAGE=${{ env.build_base_image_temurin_ubuntu }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
             IMAGE_TYPE=stable-ubuntu
@@ -243,7 +244,7 @@ jobs:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
           platforms: ${{ env.build_base_image_temurin_platform_testing }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin }}-alpine
+            BASE_IMAGE=${{ env.build_base_image_temurin_alpine }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
             IMAGE_TYPE=stable-alpine
@@ -328,7 +329,7 @@ jobs:
           platforms: ${{ env.build_base_image_temurin_platform }}
           push: ${{ needs.check_stable.outputs.enable_build_publish == 'true' }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin }}
+            BASE_IMAGE=${{ env.build_base_image_temurin_ubuntu }}
             BUILD_DATE=${{ needs.check_stable.outputs.build_date }}
             IMAGE_VERSION=${{ needs.check_stable.outputs.release_version }}
             IMAGE_TYPE=stable-ubuntu
@@ -355,7 +356,7 @@ jobs:
           platforms: ${{ env.build_base_image_temurin_platform }}
           push: ${{ needs.check_stable.outputs.enable_build_publish == 'true' }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin }}-alpine
+            BASE_IMAGE=${{ env.build_base_image_temurin_alpine }}
             BUILD_DATE=${{ needs.check_stable.outputs.build_date }}
             IMAGE_VERSION=${{ needs.check_stable.outputs.release_version }}
             IMAGE_TYPE=stable-alpine
@@ -458,7 +459,7 @@ jobs:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
           platforms: ${{ env.build_base_image_temurin_platform_testing }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin }}
+            BASE_IMAGE=${{ env.build_base_image_temurin_ubuntu }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
             IMAGE_TYPE=preview-ubuntu
@@ -509,7 +510,7 @@ jobs:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
           platforms: ${{ env.build_base_image_temurin_platform_testing }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin }}-alpine
+            BASE_IMAGE=${{ env.build_base_image_temurin_alpine }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
             IMAGE_TYPE=preview-alpine
@@ -596,7 +597,7 @@ jobs:
           platforms: ${{ env.build_base_image_temurin_platform }}
           push: ${{ needs.check_preview.outputs.enable_build_publish == 'true' }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin }}
+            BASE_IMAGE=${{ env.build_base_image_temurin_ubuntu }}
             BUILD_DATE=${{ needs.check_preview.outputs.build_date }}
             IMAGE_VERSION=${{ needs.check_preview.outputs.release_version }}
             IMAGE_TYPE=preview-ubuntu
@@ -621,7 +622,7 @@ jobs:
           platforms: ${{ env.build_base_image_temurin_platform }}
           push: ${{ needs.check_preview.outputs.enable_build_publish == 'true' }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin }}-alpine
+            BASE_IMAGE=${{ env.build_base_image_temurin_alpine }}
             BUILD_DATE=${{ needs.check_preview.outputs.build_date }}
             IMAGE_VERSION=${{ needs.check_preview.outputs.release_version }}
             IMAGE_TYPE=preview-alpine

--- a/.github/workflows/build_container_images.yml
+++ b/.github/workflows/build_container_images.yml
@@ -25,7 +25,7 @@ env:
   build_repo_docker: 'tachidesk'
   build_base_image_temurin_ubuntu: 'eclipse-temurin:11-jre-jammy'
   build_base_image_temurin_alpine: 'eclipse-temurin:11-jre-alpine'
-  build_base_image_temurin_platform: 'linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x'
+  build_base_image_temurin_platform: 'linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x'
   build_base_image_temurin_platform_testing: 'linux/amd64'
   startup_script_url: 'https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/startup_script.sh'
   tachidesk_webui_stable_url: 'https://api.github.com/repos/suwayomi/Tachidesk-Server/releases/latest'

--- a/.github/workflows/build_container_images.yml
+++ b/.github/workflows/build_container_images.yml
@@ -23,15 +23,15 @@ on:
 
 env:
   build_repo_docker: 'tachidesk'
-  build_base_image_temurin_ubuntu: 'eclipse-temurin:11-jre-jammy'
-  build_base_image_temurin_alpine: 'eclipse-temurin:11-jre-alpine'
-  build_base_image_temurin_platform: 'linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x'
+  build_base_image_temurin: 'eclipse-temurin:11-jre-jammy'
+  build_base_image_temurin_platform: 'linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x'
   build_base_image_temurin_platform_testing: 'linux/amd64'
+  build_base_image_alpine: 'alpine:3.16'
+  build_base_image_alpine_platform: 'linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x'
+  build_base_image_alpine_platform_testing: 'linux/amd64'
   startup_script_url: 'https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/startup_script.sh'
   tachidesk_webui_stable_url: 'https://api.github.com/repos/suwayomi/Tachidesk-Server/releases/latest'
   tachidesk_webui_preview_url: 'https://api.github.com/repos/suwayomi/Tachidesk-Server-preview/releases/latest'
-  java_8_version: openjdk8-jre-base
-  java_11_version: openjdk11-jre-headless
   
 jobs:
   check_workflow:
@@ -195,7 +195,7 @@ jobs:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
           platforms: ${{ env.build_base_image_temurin_platform_testing }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin_ubuntu }}
+            BASE_IMAGE=${{ env.build_base_image_temurin }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
             IMAGE_TYPE=stable-ubuntu
@@ -242,9 +242,9 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_temurin_platform_testing }}
+          platforms: ${{ env.build_base_image_alpine_platform_testing }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin_alpine }}
+            BASE_IMAGE=${{ env.build_base_image_alpine }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
             IMAGE_TYPE=stable-alpine
@@ -329,7 +329,7 @@ jobs:
           platforms: ${{ env.build_base_image_temurin_platform }}
           push: ${{ needs.check_stable.outputs.enable_build_publish == 'true' }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin_ubuntu }}
+            BASE_IMAGE=${{ env.build_base_image_temurin }}
             BUILD_DATE=${{ needs.check_stable.outputs.build_date }}
             IMAGE_VERSION=${{ needs.check_stable.outputs.release_version }}
             IMAGE_TYPE=stable-ubuntu
@@ -353,10 +353,10 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_temurin_platform }}
+          platforms: ${{ env.build_base_image_alpine_platform }}
           push: ${{ needs.check_stable.outputs.enable_build_publish == 'true' }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin_alpine }}
+            BASE_IMAGE=${{ env.build_base_image_alpine }}
             BUILD_DATE=${{ needs.check_stable.outputs.build_date }}
             IMAGE_VERSION=${{ needs.check_stable.outputs.release_version }}
             IMAGE_TYPE=stable-alpine
@@ -459,7 +459,7 @@ jobs:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
           platforms: ${{ env.build_base_image_temurin_platform_testing }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin_ubuntu }}
+            BASE_IMAGE=${{ env.build_base_image_temurin }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
             IMAGE_TYPE=preview-ubuntu
@@ -508,9 +508,9 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_temurin_platform_testing }}
+          platforms: ${{ env.build_base_image_alpine_platform_testing }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin_alpine }}
+            BASE_IMAGE=${{ env.build_base_image_alpine }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
             IMAGE_TYPE=preview-alpine
@@ -597,7 +597,7 @@ jobs:
           platforms: ${{ env.build_base_image_temurin_platform }}
           push: ${{ needs.check_preview.outputs.enable_build_publish == 'true' }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin_ubuntu }}
+            BASE_IMAGE=${{ env.build_base_image_temurin }}
             BUILD_DATE=${{ needs.check_preview.outputs.build_date }}
             IMAGE_VERSION=${{ needs.check_preview.outputs.release_version }}
             IMAGE_TYPE=preview-ubuntu
@@ -619,10 +619,10 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: scripts/dockerfiles/Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_temurin_platform }}
+          platforms: ${{ env.build_base_image_alpine_platform }}
           push: ${{ needs.check_preview.outputs.enable_build_publish == 'true' }}
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin_alpine }}
+            BASE_IMAGE=${{ env.build_base_image_alpine }}
             BUILD_DATE=${{ needs.check_preview.outputs.build_date }}
             IMAGE_VERSION=${{ needs.check_preview.outputs.release_version }}
             IMAGE_TYPE=preview-alpine

--- a/.github/workflows/build_test_images.yml
+++ b/.github/workflows/build_test_images.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   build_repo_docker: 'tachidesk'
-  build_base_image_temurin: 'eclipse-temurin:11-jre'
+  build_base_image_temurin_ubuntu: 'eclipse-temurin:11-jre-focal'
   build_base_image_temurin_platform: 'linux/amd64'
   startup_script_url: 'https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/startup_script.sh'
   tachidesk_webui_stable_url: 'https://api.github.com/repos/suwayomi/Tachidesk-Server/releases/latest'
@@ -77,7 +77,7 @@ jobs:
           platforms: ${{ env.build_base_image_temurin_platform }}
           push: true
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin }}
+            BASE_IMAGE=${{ env.build_base_image_temurin_ubuntu }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
             IMAGE_TYPE=develop-ubuntu

--- a/.github/workflows/build_test_images.yml
+++ b/.github/workflows/build_test_images.yml
@@ -18,7 +18,7 @@ env:
   build_base_image_temurin: 'eclipse-temurin:11-jre-jammy'
   build_base_image_temurin_platform: 'linux/amd64'
   build_base_image_alpine: 'alpine:3.16'
-  build_base_image_alpine_platform_testing: 'linux/amd64'
+  build_base_image_alpine_platform: 'linux/amd64'
   startup_script_url: 'https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/startup_script.sh'
   tachidesk_webui_stable_url: 'https://api.github.com/repos/suwayomi/Tachidesk-Server/releases/latest'
   

--- a/.github/workflows/build_test_images.yml
+++ b/.github/workflows/build_test_images.yml
@@ -16,6 +16,7 @@ on:
 env:
   build_repo_docker: 'tachidesk'
   build_base_image_temurin_ubuntu: 'eclipse-temurin:11-jre-jammy'
+  build_base_image_temurin_alpine: 'eclipse-temurin:11-jre-alpine'
   build_base_image_temurin_platform: 'linux/amd64'
   startup_script_url: 'https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/startup_script.sh'
   tachidesk_webui_stable_url: 'https://api.github.com/repos/suwayomi/Tachidesk-Server/releases/latest'
@@ -90,5 +91,29 @@ jobs:
             IMAGE_OWNER=${{ steps.get_latest_release_metadata.outputs.repository_owner_lower }}
           tags: |
             ghcr.io/${{ steps.get_latest_release_metadata.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:develop
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Build and push stable alpine
+        id: docker_build_release_alpine
+        uses: docker/build-push-action@v3
+        with:
+          file: scripts/dockerfiles/Test_Git_Actions-Dockerfile
+          platforms: ${{ env.build_base_image_temurin_platform }}
+          push: true
+          build-args: |
+            BASE_IMAGE=${{ env.build_base_image_temurin_alpine }}
+            BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
+            IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
+            IMAGE_TYPE=develop-alpine
+            TACHIDESK_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.release_commit }}
+            TACHIDESK_RELEASE_TAG=${{ steps.get_latest_release_metadata.outputs.release_tag }}
+            TACHIDESK_RELEASE_DOWNLOAD_URL=${{ steps.get_latest_release_metadata.outputs.release_url }}
+            TACHIDESK_FILENAME=${{ steps.get_latest_release_metadata.outputs.release_filename }}
+            STARTUP_SCRIPT_URL=${{  env.startup_script_url }}
+            TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
+            IMAGE_OWNER=${{ steps.get_latest_release_metadata.outputs.repository_owner_lower }}
+          tags: |
+            ghcr.io/${{ steps.get_latest_release_metadata.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:develop-alpine
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/build_test_images.yml
+++ b/.github/workflows/build_test_images.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   build_repo_docker: 'tachidesk'
-  build_base_image_temurin_ubuntu: 'eclipse-temurin:11-jre-focal'
+  build_base_image_temurin_ubuntu: 'eclipse-temurin:11-jre-jammy'
   build_base_image_temurin_platform: 'linux/amd64'
   startup_script_url: 'https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/startup_script.sh'
   tachidesk_webui_stable_url: 'https://api.github.com/repos/suwayomi/Tachidesk-Server/releases/latest'

--- a/.github/workflows/build_test_images.yml
+++ b/.github/workflows/build_test_images.yml
@@ -59,17 +59,17 @@ jobs:
           release_commit=$(echo $release_var | cut -f2 -d"r")
           release_filename=Tachidesk-Server-${release_var}.jar
           release_version=$(echo $release_tag | cut -c2-)
-          echo "::set-output name=release_url::$release_url"
-          echo "::set-output name=release_commit::$release_commit"
-          echo "::set-output name=release_tag::$release_tag"
-          echo "::set-output name=release_filename::$release_filename"
-          echo "::set-output name=release_version::$release_version"
-          echo "::set-output name=release_var::$release_var"
+          echo "release_url=$release_url" >> $GITHUB_OUTPUT
+          echo "release_commit=$release_commit" >> $GITHUB_OUTPUT
+          echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
+          echo "release_filename=$release_filename" >> $GITHUB_OUTPUT
+          echo "release_version=$release_version" >> $GITHUB_OUTPUT
+          echo "release_var=$release_var" >> $GITHUB_OUTPUT
           tachidesk_docker_git_commit=$(git rev-list --count HEAD)
-          echo "::set-output name=tachidesk_docker_git_commit::$tachidesk_docker_git_commit"
+          echo "tachidesk_docker_git_commit=$tachidesk_docker_git_commit" >> $GITHUB_OUTPUT
           build_date=$(date "+%F")
-          echo "::set-output name=build_date::$build_date"
-          echo "::set-output name=repository_owner_lower::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"
+          echo "build_date=$build_date" >> $GITHUB_OUTPUT
+          echo "repository_owner_lower=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
           
       - name: Build and push stable ubuntu
         id: docker_build_release_ubuntu

--- a/.github/workflows/build_test_images.yml
+++ b/.github/workflows/build_test_images.yml
@@ -15,9 +15,10 @@ on:
 
 env:
   build_repo_docker: 'tachidesk'
-  build_base_image_temurin_ubuntu: 'eclipse-temurin:11-jre-jammy'
-  build_base_image_temurin_alpine: 'eclipse-temurin:11-jre-alpine'
+  build_base_image_temurin: 'eclipse-temurin:11-jre-jammy'
   build_base_image_temurin_platform: 'linux/amd64'
+  build_base_image_alpine: 'alpine:3.16'
+  build_base_image_alpine_platform_testing: 'linux/amd64'
   startup_script_url: 'https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/startup_script.sh'
   tachidesk_webui_stable_url: 'https://api.github.com/repos/suwayomi/Tachidesk-Server/releases/latest'
   
@@ -78,7 +79,7 @@ jobs:
           platforms: ${{ env.build_base_image_temurin_platform }}
           push: true
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin_ubuntu }}
+            BASE_IMAGE=${{ env.build_base_image_temurin }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
             IMAGE_TYPE=develop-ubuntu
@@ -99,10 +100,10 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: scripts/dockerfiles/Test_Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_temurin_platform }}
+          platforms: ${{ env.build_base_image_alpine_platform }}
           push: true
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_temurin_alpine }}
+            BASE_IMAGE=${{ env.build_base_image_alpine }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
             IMAGE_TYPE=develop-alpine

--- a/.github/workflows/build_test_images.yml
+++ b/.github/workflows/build_test_images.yml
@@ -15,11 +15,10 @@ on:
 
 env:
   build_repo_docker: 'tachidesk'
-  build_base_image_alpine: 'alpine:3.16'
-  build_base_image_alpine_platform: 'linux/amd64'
+  build_base_image_temurin: 'eclipse-temurin:11-jre'
+  build_base_image_temurin_platform: 'linux/amd64'
   startup_script_url: 'https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/startup_script.sh'
   tachidesk_webui_stable_url: 'https://api.github.com/repos/suwayomi/Tachidesk-Server/releases/latest'
-  java_8_version: openjdk8-jre-base
   
 jobs:           
           
@@ -70,18 +69,18 @@ jobs:
           echo "::set-output name=build_date::$build_date"
           echo "::set-output name=repository_owner_lower::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"
           
-      - name: Build and push stable alpine
-        id: docker_build_release_alpine
+      - name: Build and push stable ubuntu
+        id: docker_build_release_ubuntu
         uses: docker/build-push-action@v3
         with:
           file: scripts/dockerfiles/Test_Git_Actions-Dockerfile
-          platforms: ${{ env.build_base_image_alpine_platform }}
+          platforms: ${{ env.build_base_image_temurin_platform }}
           push: true
           build-args: |
-            BASE_IMAGE=${{ env.build_base_image_alpine }}
+            BASE_IMAGE=${{ env.build_base_image_temurin }}
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
             IMAGE_VERSION=${{ steps.get_latest_release_metadata.outputs.release_version }}
-            IMAGE_TYPE=develop-alpine
+            IMAGE_TYPE=develop-ubuntu
             TACHIDESK_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.release_commit }}
             TACHIDESK_RELEASE_TAG=${{ steps.get_latest_release_metadata.outputs.release_tag }}
             TACHIDESK_RELEASE_DOWNLOAD_URL=${{ steps.get_latest_release_metadata.outputs.release_url }}
@@ -89,7 +88,6 @@ jobs:
             STARTUP_SCRIPT_URL=${{  env.startup_script_url }}
             TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
             IMAGE_OWNER=${{ steps.get_latest_release_metadata.outputs.repository_owner_lower }}
-            JAVA_VERSION=${{  env.java_8_version }}
           tags: |
             ghcr.io/${{ steps.get_latest_release_metadata.outputs.repository_owner_lower }}/${{ env.build_repo_docker }}:develop
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM alpine:latest
+FROM eclipse-temurin:11-jre-focal
 
-RUN apk --update add curl openjdk8-jre-base tzdata
-
-RUN addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi
+RUN groupadd -g 1000 suwayomi && adduser --gecos "" --disabled-password suwayomi --uid 1000 --gid 1000;
 
 RUN mkdir -p /home/suwayomi && chown -R suwayomi:suwayomi /home/suwayomi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:11-jre-focal
 
-RUN groupadd -g 1000 suwayomi && adduser --gecos "" --disabled-password suwayomi --uid 1000 --gid 1000;
+RUN groupadd --gid 1000 suwayomi && useradd  --uid 1000 --gid suwayomi --no-log-init suwayomi;
 
 RUN mkdir -p /home/suwayomi && chown -R suwayomi:suwayomi /home/suwayomi
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Dockerfile - https://github.com/suwayomi/docker-tachidesk
 
 _**Tachidesk data location - /home/suwayomi/.local/share/Tachidesk**_
 
-Docker images are mutli-arch (linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64, linux/ppc64le, linux/s390x) and has very small size based on alpine linux.
+Docker images are mutli-arch (linux/amd64, linux/arm/v7, linux/arm64, linux/ppc64le, linux/s390x) and has small size based on Ubuntu linux.
+
+Legacy alpine images using the `-alpine` suffix are provided for as-needed use-cases, such as:
+- Support for linux platforms linux/386 and linux/arm/v6
+- Those that need a smaller image size
 
 Log file location - /home/suwayomi/.local/share/Tachidesk/logfile.log
 

--- a/scripts/dockerfiles/Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Git_Actions-Dockerfile
@@ -16,7 +16,7 @@ ARG JAVA_VERSION
 
 RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; \
     elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then useradd -ms /bin/sh suwayomi && \
-        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else sudo apt install libc++-dev -y; fi; \
+        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else apt install libc++-dev -y; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Git_Actions-Dockerfile
@@ -14,8 +14,12 @@ ARG TACHIDESK_DOCKER_GIT_COMMIT
 ARG STARTUP_SCRIPT_URL
 ARG JAVA_VERSION
 
-RUN if echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
-	elif echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; else echo "wrong base image"; fi
+RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; \
+    elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then useradd -ms /bin/sh suwayomi && \
+        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else sudo apt install libc++-dev -y; fi; \
+    elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
+    else echo "wrong base image"; \
+    fi
 
 LABEL maintainer="suwayomi" \
       org.opencontainers.image.title="Tachidesk Docker" \

--- a/scripts/dockerfiles/Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Git_Actions-Dockerfile
@@ -16,7 +16,7 @@ ARG JAVA_VERSION
 
 RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; \
     elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then useradd -ms /bin/sh suwayomi && \
-        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else apt install libc++-dev -y; fi; \
+        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else sudo apt update;sudo apt install libc++-dev -y; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Git_Actions-Dockerfile
@@ -18,7 +18,7 @@ RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi
         if echo "$BASE_IMAGE" | grep -q "alpine"; then \
             apk --update add curl tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
         else \
-            useradd -ms /bin/sh suwayomi; fi; \
+            groupadd -g 1000 suwayomi && adduser --gecos "" --disabled-password suwayomi --uid 1000 --gid 1000; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl openjdk8-jre-base tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Git_Actions-Dockerfile
@@ -16,7 +16,7 @@ ARG JAVA_VERSION
 
 RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; \
     elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then useradd -ms /bin/sh suwayomi && \
-        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else sudo apt update;sudo apt install libc++-dev -y; fi; \
+        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else sudo apt update; sudo apt install libc++-dev -y; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Git_Actions-Dockerfile
@@ -18,7 +18,7 @@ RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi
         if echo "$BASE_IMAGE" | grep -q "alpine"; then \
             apk --update add curl tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
         else \
-            groupadd -g 1000 suwayomi && adduser --gecos "" --disabled-password suwayomi --uid 1000 --gid 1000; fi; \
+            groupadd --gid 1000 suwayomi && useradd  --uid 1000 --gid suwayomi --no-log-init suwayomi; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl openjdk8-jre-base tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Git_Actions-Dockerfile
@@ -18,7 +18,7 @@ RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi
         if echo "$BASE_IMAGE" | grep -q "alpine"; then \
             apk --update add curl tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
         else \
-            useradd -ms /bin/sh suwayomi && apt update && apt install libc++-dev -y; fi; \
+            useradd -ms /bin/sh suwayomi; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl openjdk8-jre-base tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Git_Actions-Dockerfile
@@ -16,7 +16,7 @@ ARG JAVA_VERSION
 
 RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; \
     elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then useradd -ms /bin/sh suwayomi && \
-        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else sudo apt update; sudo apt install libc++-dev -y; fi; \
+        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else apt update; apt install libc++-dev -y; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Git_Actions-Dockerfile
@@ -15,8 +15,11 @@ ARG STARTUP_SCRIPT_URL
 ARG JAVA_VERSION
 
 RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; \
-    elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then useradd -ms /bin/sh suwayomi && \
-        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else apt update; apt install libc++-dev -y; fi; \
+    elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then \
+        if echo "$BASE_IMAGE" | grep -q "alpine"; then \
+            apk --update add curl tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
+        else \
+            useradd -ms /bin/sh suwayomi && apt update && apt install libc++-dev -y; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Git_Actions-Dockerfile
@@ -12,7 +12,6 @@ ARG TACHIDESK_FILENAME
 ARG TACHIDESK_RELEASE_DOWNLOAD_URL
 ARG TACHIDESK_DOCKER_GIT_COMMIT
 ARG STARTUP_SCRIPT_URL
-ARG JAVA_VERSION
 
 RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; \
     elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then \
@@ -20,7 +19,7 @@ RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi
             apk --update add curl tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
         else \
             useradd -ms /bin/sh suwayomi && apt update && apt install libc++-dev -y; fi; \
-    elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
+    elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl openjdk8-jre-base tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi
 

--- a/scripts/dockerfiles/Test_Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Test_Git_Actions-Dockerfile
@@ -16,7 +16,7 @@ ARG JAVA_VERSION
 
 RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; \
     elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then useradd -ms /bin/sh suwayomi && \
-        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else sudo apt install libc++-dev -y; fi; \
+        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else apt install libc++-dev -y; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Test_Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Test_Git_Actions-Dockerfile
@@ -14,8 +14,12 @@ ARG TACHIDESK_DOCKER_GIT_COMMIT
 ARG STARTUP_SCRIPT_URL
 ARG JAVA_VERSION
 
-RUN if echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
-	elif echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; else echo "wrong base image"; fi
+RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; \
+    elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then useradd -ms /bin/sh suwayomi && \
+        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else sudo apt install libc++-dev -y; fi; \
+    elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
+    else echo "wrong base image"; \
+    fi
 
 LABEL maintainer="suwayomi" \
       org.opencontainers.image.title="Tachidesk Docker" \

--- a/scripts/dockerfiles/Test_Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Test_Git_Actions-Dockerfile
@@ -16,7 +16,7 @@ ARG JAVA_VERSION
 
 RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; \
     elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then useradd -ms /bin/sh suwayomi && \
-        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else apt install libc++-dev -y; fi; \
+        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else sudo apt update;sudo apt install libc++-dev -y; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Test_Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Test_Git_Actions-Dockerfile
@@ -18,7 +18,7 @@ RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi
         if echo "$BASE_IMAGE" | grep -q "alpine"; then \
             apk --update add curl tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
         else \
-            useradd -ms /bin/sh suwayomi; fi; \
+            groupadd -g 1000 suwayomi && adduser --gecos "" --disabled-password suwayomi --uid 1000 --gid 1000; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl openjdk8-jre-base tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Test_Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Test_Git_Actions-Dockerfile
@@ -18,7 +18,7 @@ RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi
         if echo "$BASE_IMAGE" | grep -q "alpine"; then \
             apk --update add curl tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
         else \
-            groupadd -g 1000 suwayomi && adduser --gecos "" --disabled-password suwayomi --uid 1000 --gid 1000; fi; \
+            groupadd --gid 1000 suwayomi && useradd  --uid 1000 --gid suwayomi --no-log-init suwayomi; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl openjdk8-jre-base tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Test_Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Test_Git_Actions-Dockerfile
@@ -18,7 +18,7 @@ RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi
         if echo "$BASE_IMAGE" | grep -q "alpine"; then \
             apk --update add curl tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
         else \
-            useradd -ms /bin/sh suwayomi && apt update && apt install libc++-dev -y; fi; \
+            useradd -ms /bin/sh suwayomi; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl openjdk8-jre-base tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Test_Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Test_Git_Actions-Dockerfile
@@ -15,8 +15,11 @@ ARG STARTUP_SCRIPT_URL
 ARG JAVA_VERSION
 
 RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; \
-    elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then useradd -ms /bin/sh suwayomi && \
-        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else apt update; apt install libc++-dev -y; fi; \
+    elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then \
+        if echo "$BASE_IMAGE" | grep -q "alpine"; then \
+            apk --update add curl tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
+        else \
+            useradd -ms /bin/sh suwayomi && apt update && apt install libc++-dev -y; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi

--- a/scripts/dockerfiles/Test_Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Test_Git_Actions-Dockerfile
@@ -12,7 +12,6 @@ ARG TACHIDESK_FILENAME
 ARG TACHIDESK_RELEASE_DOWNLOAD_URL
 ARG TACHIDESK_DOCKER_GIT_COMMIT
 ARG STARTUP_SCRIPT_URL
-ARG JAVA_VERSION
 
 RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; \
     elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then \
@@ -20,7 +19,7 @@ RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi
             apk --update add curl tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
         else \
             useradd -ms /bin/sh suwayomi && apt update && apt install libc++-dev -y; fi; \
-    elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
+    elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl openjdk8-jre-base tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi
 

--- a/scripts/dockerfiles/Test_Git_Actions-Dockerfile
+++ b/scripts/dockerfiles/Test_Git_Actions-Dockerfile
@@ -16,7 +16,7 @@ ARG JAVA_VERSION
 
 RUN if echo "$BASE_IMAGE" | grep -q "openjdk"; then useradd -ms /bin/sh suwayomi; \
     elif echo "$BASE_IMAGE" | grep -q "eclipse-temurin"; then useradd -ms /bin/sh suwayomi && \
-        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else sudo apt update;sudo apt install libc++-dev -y; fi; \
+        if echo "$BASE_IMAGE" | grep -q "alpine"; then echo "QuickJS not supported"; else apt update; apt install libc++-dev -y; fi; \
     elif echo "$BASE_IMAGE" | grep -q "alpine"; then apk --update add curl "$JAVA_VERSION" tzdata && addgroup -g 1000 -S suwayomi && adduser -u 1000 -S suwayomi -G suwayomi; \
     else echo "wrong base image"; \
     fi


### PR DESCRIPTION
Use eclipse-temurin:11-jre as the new base image instead of alpine. 

Alpine will be avalible as a suffix to the normal tags. It would be a backup for people who are on platforms that Temurin does not support, such as x32 and Arm V6.

Effective changes:
- Defaults to Java 11 as a base, we could even use Java 17 if we did some testing to make sure everything works properly.
- `latest,stable,preview` will point to the ubuntu image of the tag.
- `latest-alpine,stable-alpine,preview-alpine` was added for those who are on platforms not supported by Temurin, or who care for space.
- `latest-ubuntu,stable-ubuntu,preview-ubuntu` were added for explicit ubuntu use.

I will see if I can get this tested before unmarking this as a draft.