### PR TITLE
Split the workflow into multiple files

### DIFF
--- a/.github/workflows/build_container_images.yml
+++ b/.github/workflows/build_container_images.yml
@@ -1,120 +1,20 @@
 name: Build Container Images
-on:
-  push:
-    branches: [ main ]
-    paths-ignore:
-      - '**/README.md'
-  workflow_dispatch:
-     inputs:
-        tachidesk_release_type:
-          required: true
-          default: 'preview'
-          description: 'Suwayomi Release Type'
-          type: choice
-          options:
-            - stable
-            - preview
 
-env:
-  server_repo: ${{ inputs.tachidesk_release_type == 'stable' && 'Tachidesk-Server' || 'Tachidesk-Server-preview' }}
-  test_image_tag: ghcr.io/suwayomi/tachidesk:testing
-  this_actions_run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+on:
+  workflow_dispatch:
+    inputs:
+      tachidesk_release_type:
+        required: true
+        default: 'preview'
+        description: 'Suwayomi Release Type'
+        type: choice
+        options:
+          - stable
+          - preview
 
 jobs:
-  build_stable:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          # We want a full clone of the repo so that the rev-list count below is correct
-          fetch-depth: 0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get latest release metadata
-        id: get_latest_release_metadata
-        run: |
-          curl -s https://api.github.com/repos/suwayomi/${{ env.server_repo }}/releases/latest > ${{ runner.temp }}/latest_release.json
-          release_url=$(jq -r '.assets[] | select(.content_type == "application/java-archive") | .browser_download_url' ${{ runner.temp }}/latest_release.json)
-          release_tag=$(jq -r '.tag_name' ${{ runner.temp }}/latest_release.json)
-          release_filename=$(basename $release_url)
-          tachidesk_docker_git_commit=$(git rev-list --count HEAD)
-          build_date=$(date "+%F")
-          echo "release_url=$release_url" >> $GITHUB_OUTPUT
-          echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
-          echo "release_filename=$release_filename" >> $GITHUB_OUTPUT
-          echo "tachidesk_docker_git_commit=$tachidesk_docker_git_commit" >> $GITHUB_OUTPUT
-          echo "build_date=$build_date" >> $GITHUB_OUTPUT
-
-      # this only builds the amd64 version of the image, which is fine as that's
-      # all that is needed to test the container on Github Actions' build servers (which are running amd64 CPUs)
-      - name: Build container image to test
-        uses: docker/build-push-action@v3
-        with:
-          load: true # this is important, as this tells build-push-action to save the container to the local docker daemon
-          build-args: |
-            BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
-            TACHIDESK_RELEASE_TAG=${{ steps.get_latest_release_metadata.outputs.release_tag }}
-            TACHIDESK_RELEASE_DOWNLOAD_URL=${{ steps.get_latest_release_metadata.outputs.release_url }}
-            TACHIDESK_FILENAME=${{ steps.get_latest_release_metadata.outputs.release_filename }}
-            TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
-          tags: ${{ env.test_image_tag }}
-
-      # Launch the container and then hit the about API to verifiy that it can start up correctly.
-      - name: Test new container image
-        run: |
-            mkdir -p ${{ runner.temp }}/tachidesk
-            chmod -R 777 ${{ runner.temp }}/tachidesk
-            docker run --rm -d -p 127.0.0.1:4568:4567 -v ${{ runner.temp }}/tachidesk:/home/suwayomi/.local/share/Tachidesk --name=suwayomi_test ${{ env.test_image_tag }}
-            sleep 15
-            curl -s 127.0.0.1:4568/api/v1/settings/about/ && val=$(curl -s 127.0.0.1:4568/api/v1/settings/about/ | grep -o "Tachidesk" | sort --unique)
-            docker logs suwayomi_test > ${{ runner.temp }}/tachidesk.log
-            if [[ $val != "Tachidesk" ]]; then
-              echo "Did not find Tachidesk in server response: ${val}"
-              curl \
-                -F 'payload_json={"username": "Github", "content": "<@855022649926221854>\nDocker ${{ inputs.tachidesk_release_type }} image dry run failed! 😢 Version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}. [See the full run log](${{ env.this_actions_run_url }})"}' \
-                -F "file1=@${{ runner.temp }}/tachidesk.log" \
-                "https://discord.com/api/webhooks/${{ secrets.DISCORD_TACHIDESK_WEBHOOK_ID }}/${{ secrets.DISCORD_TACHIDESK_TOKEN }}"
-              exit 1
-            fi
-
-      # Now we build for all of the platforms we support here. NB: the amd64
-      # won't be rebuilt since the local docker daemon has that still cached
-      - name: Push container image to registry
-        uses: docker/build-push-action@v3
-        with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
-          push: true
-          build-args: |
-            BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
-            TACHIDESK_RELEASE_TAG=${{ steps.get_latest_release_metadata.outputs.release_tag }}
-            TACHIDESK_RELEASE_DOWNLOAD_URL=${{ steps.get_latest_release_metadata.outputs.release_url }}
-            TACHIDESK_FILENAME=${{ steps.get_latest_release_metadata.outputs.release_filename }}
-            TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
-          tags: |
-            ghcr.io/suwayomi/tachidesk:latest
-            ghcr.io/suwayomi/tachidesk:${{ inputs.tachidesk_release_type }}
-            ghcr.io/suwayomi/tachidesk:${{ inputs.tachidesk_release_type == 'stable' && steps.get_latest_release_metadata.outputs.release_tag }}
-
-      - name: Send a Discord message through the webhook (preview build)
-        if: inputs.tachidesk_release_type == 'preview'
-        run: |
-          curl -H "Content-Type: application/json" -d '{"content": "Docker Preview Image Published!","embeds":[{"color":16729344,"author":{"name":"${{ github.repository_owner }}","icon_url":"https://avatars.githubusercontent.com/u/81182076","url":"https://github.com/${{ github.repository_owner }}"},"title":"Docker Preview Release","url":"https://github.com/${{ github.repository_owner }}/docker-tachidesk","fields":[{"name":"docker update","value":"docker pull ghcr.io/suwayomi/tachidesk:preview","inline":false},{"name":"docker run","value":"docker run -p 4567:4567 ghcr.io/suwayomi/tachidesk:preview","inline":false}],"thumbnail":{"url": "https://www.docker.com/sites/default/files/d8/2019-07/vertical-logo-monochromatic.png"},"description":"Tachidesk version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}]}' "https://discord.com/api/webhooks/${{ secrets.DISCORD_TACHIDESK_WEBHOOK_ID }}/${{ secrets.DISCORD_TACHIDESK_TOKEN }}"
-
-      - name: Send a Discord message through the webhook (stable build)
-        if: inputs.tachidesk_release_type == 'stable'
-        run: |
-          curl -H "Content-Type: application/json" -d '{"content": "Docker Stable Image Published!","embeds":[{"color":5409028,"author":{"name":"${{ github.repository_owner }}","icon_url":"https://avatars.githubusercontent.com/u/81182076","url":"https://github.com/${{ github.repository_owner }}"},"title":"Docker Stable Release","url":"https://github.com/${{ github.repository_owner }}/docker-tachidesk","fields":[{"name":"docker update","value":"docker pull ghcr.io/suwayomi/tachidesk:stable","inline":false},{"name":"docker run","value":"docker run -p 4567:4567 ghcr.io/suwayomi/tachidesk","inline":false}],"thumbnail":{"url": "https://www.docker.com/sites/default/files/d8/2019-07/vertical-logo-monochromatic.png"},"description":"Tachidesk version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}]}' "https://discord.com/api/webhooks/${{ secrets.DISCORD_TACHIDESK_WEBHOOK_ID }}/${{ secrets.DISCORD_TACHIDESK_TOKEN }}"
+  go:
+    uses: ./.github/workflows/container.yml
+    with:
+      tachidesk_release_type: ${{ inputs.tachidesk_release_type }}
+      do_upload: true

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,123 @@
+name: Build a container
+
+on:
+  workflow_call:
+    inputs:
+      tachidesk_release_type:
+        required: true
+        default: 'preview'
+        description: 'Suwayomi Release Type'
+        type: choice
+        options:
+          - stable
+          - preview
+      do_upload:
+        required: true
+        default: true
+        description: 'Should the image be uploaded to the registry?'
+        type: boolean
+
+env:
+  server_repo: ${{ inputs.tachidesk_release_type == 'stable' && 'Tachidesk-Server' || 'Tachidesk-Server-preview' }}
+  test_image_tag: ghcr.io/suwayomi/tachidesk:testing
+  this_actions_run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+jobs:
+  build_the_container:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # We want a full clone of the repo so that the rev-list count below is correct
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get latest release metadata
+        id: get_latest_release_metadata
+        run: |
+          curl -s https://api.github.com/repos/suwayomi/${{ env.server_repo }}/releases/latest > ${{ runner.temp }}/latest_release.json
+          release_url=$(jq -r '.assets[] | select(.content_type == "application/java-archive") | .browser_download_url' ${{ runner.temp }}/latest_release.json)
+          release_tag=$(jq -r '.tag_name' ${{ runner.temp }}/latest_release.json)
+          release_filename=$(basename $release_url)
+          tachidesk_docker_git_commit=$(git rev-list --count HEAD)
+          build_date=$(date "+%F")
+          echo "release_url=$release_url" >> $GITHUB_OUTPUT
+          echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
+          echo "release_filename=$release_filename" >> $GITHUB_OUTPUT
+          echo "tachidesk_docker_git_commit=$tachidesk_docker_git_commit" >> $GITHUB_OUTPUT
+          echo "build_date=$build_date" >> $GITHUB_OUTPUT
+
+      # this only builds the amd64 version of the image, which is fine as that's
+      # all that is needed to test the container on Github Actions' build servers (which are running amd64 CPUs)
+      - name: Build container image to test
+        uses: docker/build-push-action@v3
+        with:
+          load: true # this is important, as this tells build-push-action to save the container to the local docker daemon
+          build-args: |
+            BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
+            TACHIDESK_RELEASE_TAG=${{ steps.get_latest_release_metadata.outputs.release_tag }}
+            TACHIDESK_RELEASE_DOWNLOAD_URL=${{ steps.get_latest_release_metadata.outputs.release_url }}
+            TACHIDESK_FILENAME=${{ steps.get_latest_release_metadata.outputs.release_filename }}
+            TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
+          tags: ${{ env.test_image_tag }}
+
+      # Launch the container and then hit the about API to verifiy that it can start up correctly.
+      - name: Test new container image
+        run: |
+            mkdir -p ${{ runner.temp }}/tachidesk
+            chmod -R 777 ${{ runner.temp }}/tachidesk
+            docker run --rm -d -p 127.0.0.1:4568:4567 -v ${{ runner.temp }}/tachidesk:/home/suwayomi/.local/share/Tachidesk --name=suwayomi_test ${{ env.test_image_tag }}
+            sleep 15
+            curl -s 127.0.0.1:4568/api/v1/settings/about/ && val=$(curl -s 127.0.0.1:4568/api/v1/settings/about/ | grep -o "Tachidesk" | sort --unique)
+            docker logs suwayomi_test > ${{ runner.temp }}/tachidesk.log
+            if [[ $val != "Tachidesk" ]]; then
+              echo "Did not find Tachidesk in server response: ${val}"
+              curl \
+                -F 'payload_json={"username": "Github", "content": "<@855022649926221854>\nDocker ${{ inputs.tachidesk_release_type }} image dry run failed! 😢 Version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}. [See the full run log](${{ env.this_actions_run_url }})"}' \
+                -F "file1=@${{ runner.temp }}/tachidesk.log" \
+                "https://discord.com/api/webhooks/${{ secrets.DISCORD_TACHIDESK_WEBHOOK_ID }}/${{ secrets.DISCORD_TACHIDESK_TOKEN }}"
+              exit 1
+            fi
+
+      # Now we build for all of the platforms we support here. NB: the amd64
+      # won't be rebuilt since the local docker daemon has that still cached
+      - name: Push container image to registry
+        if: inputs.do_upload
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          push: true
+          build-args: |
+            BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
+            TACHIDESK_RELEASE_TAG=${{ steps.get_latest_release_metadata.outputs.release_tag }}
+            TACHIDESK_RELEASE_DOWNLOAD_URL=${{ steps.get_latest_release_metadata.outputs.release_url }}
+            TACHIDESK_FILENAME=${{ steps.get_latest_release_metadata.outputs.release_filename }}
+            TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
+          tags: |
+            ${{ inputs.tachidesk_release_type == 'stable' && 'ghcr.io/suwayomi/tachidesk:latest' || '' }}
+            ghcr.io/suwayomi/tachidesk:${{ inputs.tachidesk_release_type }}
+            ghcr.io/suwayomi/tachidesk:${{ steps.get_latest_release_metadata.outputs.release_tag }}
+
+      - name: Send a Discord message through the webhook (preview build)
+        if: inputs.do_upload && inputs.tachidesk_release_type == 'preview'
+        run: |
+          curl -H "Content-Type: application/json" -d '{"content": "Docker Preview Image Published!","embeds":[{"color":16729344,"author":{"name":"${{ github.repository_owner }}","icon_url":"https://avatars.githubusercontent.com/u/81182076","url":"https://github.com/${{ github.repository_owner }}"},"title":"Docker Preview Release","url":"https://github.com/${{ github.repository_owner }}/docker-tachidesk","fields":[{"name":"docker update","value":"docker pull ghcr.io/suwayomi/tachidesk:preview","inline":false},{"name":"docker run","value":"docker run -p 4567:4567 ghcr.io/suwayomi/tachidesk:preview","inline":false}],"thumbnail":{"url": "https://www.docker.com/sites/default/files/d8/2019-07/vertical-logo-monochromatic.png"},"description":"Tachidesk version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}]}' "https://discord.com/api/webhooks/${{ secrets.DISCORD_TACHIDESK_WEBHOOK_ID }}/${{ secrets.DISCORD_TACHIDESK_TOKEN }}"
+
+      - name: Send a Discord message through the webhook (stable build)
+        if: inputs.do_upload && inputs.tachidesk_release_type == 'stable'
+        run: |
+          curl -H "Content-Type: application/json" -d '{"content": "Docker Stable Image Published!","embeds":[{"color":5409028,"author":{"name":"${{ github.repository_owner }}","icon_url":"https://avatars.githubusercontent.com/u/81182076","url":"https://github.com/${{ github.repository_owner }}"},"title":"Docker Stable Release","url":"https://github.com/${{ github.repository_owner }}/docker-tachidesk","fields":[{"name":"docker update","value":"docker pull ghcr.io/suwayomi/tachidesk:stable","inline":false},{"name":"docker run","value":"docker run -p 4567:4567 ghcr.io/suwayomi/tachidesk","inline":false}],"thumbnail":{"url": "https://www.docker.com/sites/default/files/d8/2019-07/vertical-logo-monochromatic.png"},"description":"Tachidesk version - ${{ steps.get_latest_release_metadata.outputs.release_tag }}"}]}' "https://discord.com/api/webhooks/${{ secrets.DISCORD_TACHIDESK_WEBHOOK_ID }}/${{ secrets.DISCORD_TACHIDESK_TOKEN }}"

--- a/.github/workflows/preview_build_on_push.yml
+++ b/.github/workflows/preview_build_on_push.yml
@@ -1,0 +1,16 @@
+name: Build container of the preview release
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**/README.md'
+  pull_request:
+
+jobs:
+  go:
+    uses: ./.github/workflows/container.yml
+    with:
+      tachidesk_release_type: 'preview'
+      # i.e. only upload the container on push-to-main
+      do_upload: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
Now, container.yml is the central place for all of the logic. It is never invoked directly, instead it is called by sibling workflows 'build_container_images.yml' and 'preview_build_on_push.yml'.