### PR TITLE
Support running as arbitrary UID/GID using gosu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,24 +23,30 @@ LABEL maintainer="suwayomi" \
 
 # Install envsubst from GNU's gettext project
 RUN apt-get update && \
-    apt-get -y install gettext-base && \
+    apt-get -y install gettext-base gosu && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Create a user to run as
 RUN groupadd --gid 1000 suwayomi && \
     useradd  --uid 1000 --gid suwayomi --no-log-init suwayomi && \
-    mkdir -p /home/suwayomi && \
-    chown -R suwayomi:suwayomi /home/suwayomi
-USER suwayomi
-WORKDIR /home/suwayomi
+    mkdir -p /home/suwayomi
 
+RUN mkdir -p /home/suwayomi/.local/share/Tachidesk
 # Copy the app into the container
 RUN curl -s --create-dirs -L $TACHIDESK_RELEASE_DOWNLOAD_URL -o /home/suwayomi/startup/tachidesk_latest.jar
 COPY scripts/startup_script.sh /home/suwayomi/startup_script.sh
 COPY server.conf.template /home/suwayomi/server.conf.template
+COPY entrypoint.sh /entrypoint.sh
 
+# ensure the .jar and scripts created above are owned by the correct UID/GID
+RUN chown -R suwayomi:suwayomi /home/suwayomi
+
+USER suwayomi
+WORKDIR /home/suwayomi
 EXPOSE 4567
-CMD ["/bin/sh", "/home/suwayomi/startup_script.sh"]
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/home/suwayomi/startup_script.sh"]
 
 # vim: set ft=dockerfile:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ There are a number of environment variables available to configure Suwayomi:
 | **BACKUP_TIME** | `"00:00"` | Range: hour: 0-23, minute: 0-59 - Time of day at which the automated backup should be triggered |
 | **BACKUP_INTERVAL** | `1` | # Time in days - 0 to disable it - range: 1 <= n < ∞ - Interval in which the server will automatically create a backup |
 | **BACKUP_TTL** | `14` | # Time in days - 0 to disable it - range: 1 <= n < ∞ - How long backup files will be kept before they will get deleted |
+| **PUID** | `1000` | Alternative UID to run as. Requires setting --user 0. |
+| **PGID** | `1000` | Alternative GID to run as. Requires setting --user 0. |
 
 # Docker tags
 
@@ -97,6 +99,10 @@ Persistent data of tachidesk on subsequent run
 For Specific Tachidesk stable version (from v0.3.9 onwards)
 
      docker run -p 127.0.0.1:4567:4567 ghcr.io/suwayomi/tachidesk:v0.3.9
+
+Alternative UID/GID. To run as an alternative UID and GID you need to run the container as root, and specify the `PUID` and `PGID` environment variables.
+
+     docker run -u 0 -e PUID=99 -e PGID=100 ghcr.io/suwayomi/tachidesk:preview
 
 # Credit
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+export PUID="${PUID:-"1000"}"
+export PGID="${PGID:-"1000"}"
+ARGS=()
+
+if [[ "${UID}" = 0 ]]; then
+  echo "Running as root, changing to $PUID:$PGID"
+  # this ensures the existing files created in the image can be read
+  usermod suwayomi -u "$PUID" -g "$PGID"
+  # use gosu to change UID/GID
+  ARGS+=(gosu "$PUID:$PGID")
+else
+  echo "Running as $(id -u):$(id -g)"
+fi
+
+# use the eclipse-temurin entrypoint and execute the program specified in the
+# arguments.
+# If the UID is 0, use GOSU to change to PUID/PGUD
+exec "/__cacert_entrypoint.sh" "${ARGS[@]}" "$@"

--- a/scripts/startup_script.sh
+++ b/scripts/startup_script.sh
@@ -37,4 +37,4 @@ export EXTENSION_REPOS="${EXTENSION_REPOS:-"[]"}"
 
 envsubst < /home/suwayomi/server.conf.template > /home/suwayomi/.local/share/Tachidesk/server.conf
 
-exec java -jar "/home/suwayomi/startup/tachidesk_latest.jar";
+exec java -jar "/home/suwayomi/startup/tachidesk_latest.jar"


### PR DESCRIPTION
Introduce a custom entrypoint script that executes the tachidesk application using the UID/GID specified by $PUID and $PGID respectively. Running as an alternative user requires running the container as root, since you cannot use gosu as non-root.

Closes #72 