### PR TITLE
Support running as alternative UID/GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,8 @@ RUN apt-get update && \
 # Create a user to run as
 RUN groupadd --gid 1000 suwayomi && \
     useradd  --uid 1000 --gid suwayomi --no-log-init suwayomi && \
-    mkdir -p /home/suwayomi && \
-    chown -R suwayomi:suwayomi /home/suwayomi
-USER suwayomi
+    mkdir -p /home/suwayomi/.local/share/Tachidesk
+
 WORKDIR /home/suwayomi
 
 # Copy the app into the container
@@ -40,7 +39,17 @@ RUN curl -s --create-dirs -L $TACHIDESK_RELEASE_DOWNLOAD_URL -o /home/suwayomi/s
 COPY scripts/startup_script.sh /home/suwayomi/startup_script.sh
 COPY server.conf.template /home/suwayomi/server.conf.template
 
+# update permissions of files.
+# we grant o+rwx because we need to allow non default UIDs (eg via docker run ... --user)
+# to write to the directory to generate the server.conf
+RUN chown -R suwayomi:suwayomi /home/suwayomi && \
+    chmod 777 -R /home/suwayomi
+
+# /etc/passwd needs to be writable by non default UIDs to support updating
+RUN chmod o+rw /etc/passwd
+
+USER suwayomi
 EXPOSE 4567
-CMD ["/bin/sh", "/home/suwayomi/startup_script.sh"]
+CMD ["/home/suwayomi/startup_script.sh"]
 
 # vim: set ft=dockerfile:

--- a/scripts/startup_script.sh
+++ b/scripts/startup_script.sh
@@ -35,6 +35,26 @@ export BACKUP_INTERVAL="${BACKUP_INTERVAL:-1}"
 export BACKUP_TTL="${BACKUP_TTL:-14}"
 export EXTENSION_REPOS="${EXTENSION_REPOS:-"[]"}"
 
+USERNAME="suwayomi"
+HOME="/home/${USERNAME}"
+
+# add UID/GID to /etc/passwd if missing, in order for Java's user.home property to work correctly with non default UIDs.
+if ! whoami  >/dev/null 2>&1; then
+  if [ -w /etc/passwd ]; then
+    echo "Adding user ${USERNAME} with current UID:GID $(id -u):$(id -g) to /etc/passwd"
+    # Remove existing entry with user first.
+    # cannot use sed -i because we do not have permission to write new
+    # files into /etc
+    sed  "/${USERNAME}:x/d" /etc/passwd > /tmp/passwd
+    # add our user with our current user ID into passwd
+    echo "${USERNAME}:x:$(id -u):$(id -g):${USERNAME} user:${HOME}:/bin/bash" >> /tmp/passwd
+    # overwrite existing contents with new contents (cannot replace the
+    # file due to permissions)
+    cat /tmp/passwd > /etc/passwd
+    rm /tmp/passwd
+  fi
+fi
+
 envsubst < /home/suwayomi/server.conf.template > /home/suwayomi/.local/share/Tachidesk/server.conf
 
 exec java -jar "/home/suwayomi/startup/tachidesk_latest.jar";


### PR DESCRIPTION
Because we use the Java user.home property to get the default configuration directory, there needs to be an entry for the correct user in /etc/passwd. For this to work with arbitrary UID/GID, that means updating /etc/shadow dynamically based on the UID/GID in the container before starting the application.