### PR TITLE
Set user.home property and remove /etc/passwd modifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,6 @@ COPY server.conf.template /home/suwayomi/server.conf.template
 RUN chown -R suwayomi:suwayomi /home/suwayomi && \
     chmod 777 -R /home/suwayomi
 
-# /etc/passwd needs to be writable by non default UIDs to support updating
-RUN chmod o+rw /etc/passwd
-
 USER suwayomi
 EXPOSE 4567
 CMD ["/home/suwayomi/startup_script.sh"]

--- a/scripts/startup_script.sh
+++ b/scripts/startup_script.sh
@@ -35,26 +35,6 @@ export BACKUP_INTERVAL="${BACKUP_INTERVAL:-1}"
 export BACKUP_TTL="${BACKUP_TTL:-14}"
 export EXTENSION_REPOS="${EXTENSION_REPOS:-"[]"}"
 
-USERNAME="suwayomi"
-HOME="/home/${USERNAME}"
-
-# add UID/GID to /etc/passwd if missing, in order for Java's user.home property to work correctly with non default UIDs.
-if ! whoami  >/dev/null 2>&1; then
-  if [ -w /etc/passwd ]; then
-    echo "Adding user ${USERNAME} with current UID:GID $(id -u):$(id -g) to /etc/passwd"
-    # Remove existing entry with user first.
-    # cannot use sed -i because we do not have permission to write new
-    # files into /etc
-    sed  "/${USERNAME}:x/d" /etc/passwd > /tmp/passwd
-    # add our user with our current user ID into passwd
-    echo "${USERNAME}:x:$(id -u):$(id -g):${USERNAME} user:${HOME}:/bin/bash" >> /tmp/passwd
-    # overwrite existing contents with new contents (cannot replace the
-    # file due to permissions)
-    cat /tmp/passwd > /etc/passwd
-    rm /tmp/passwd
-  fi
-fi
-
 envsubst < /home/suwayomi/server.conf.template > /home/suwayomi/.local/share/Tachidesk/server.conf
 
-exec java -jar "/home/suwayomi/startup/tachidesk_latest.jar";
+exec java -Duser.home=/home/suwayomi -jar "/home/suwayomi/startup/tachidesk_latest.jar";


### PR DESCRIPTION
If we explicitly set the user.home property, then Java doesn't consult /etc/passwd to determine $HOME, fixing the problems that necessitated updating /etc/passwd in the first place.