### PR TITLE
Add option to skip generating server.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ There are a number of environment variables available to configure Suwayomi:
 | **BACKUP_TIME** | `"00:00"` | Range: hour: 0-23, minute: 0-59 - Time of day at which the automated backup should be triggered |
 | **BACKUP_INTERVAL** | `1` | # Time in days - 0 to disable it - range: 1 <= n < ∞ - Interval in which the server will automatically create a backup |
 | **BACKUP_TTL** | `14` | # Time in days - 0 to disable it - range: 1 <= n < ∞ - How long backup files will be kept before they will get deleted |
+| **GENERATE_CONFIG** | `true` | If true, server.conf is generating using the env-vars defined. If false, you can provide your own server.conf in a volume. |
 
 # Docker tags
 

--- a/scripts/startup_script.sh
+++ b/scripts/startup_script.sh
@@ -34,7 +34,13 @@ export BACKUP_TIME="${BACKUP_TIME:-"00:00"}"
 export BACKUP_INTERVAL="${BACKUP_INTERVAL:-1}"
 export BACKUP_TTL="${BACKUP_TTL:-14}"
 export EXTENSION_REPOS="${EXTENSION_REPOS:-"[]"}"
+export GENERATE_CONFIG="${GENERATE_CONFIG:-true}"
 
-envsubst < /home/suwayomi/server.conf.template > /home/suwayomi/.local/share/Tachidesk/server.conf
+if [ "${GENERATE_CONFIG}" = true ]; then
+  echo "Generating server.conf"
+  envsubst < /home/suwayomi/server.conf.template > /home/suwayomi/.local/share/Tachidesk/server.conf
+else
+  echo "\$GENERATE_CONFIG=true, skipping generation of server.conf"
+fi
 
 exec java -Duser.home=/home/suwayomi -jar "/home/suwayomi/startup/tachidesk_latest.jar";


### PR DESCRIPTION
Some users want to manage `server.conf` themselves, without env-vars, this PR adds an option skip generation of `server.conf` so they can provide it directly in their volume instead.