### PR TITLE
Fix permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ RUN apt-get update && \
 
 # Create a user to run as
 RUN userdel -r ubuntu
-RUN groupadd --gid 1000 suwayomi && \
-    useradd  --uid 1000 --gid suwayomi --no-log-init suwayomi && \
+RUN groupadd --gid ${GID:-1000} suwayomi && \
+    useradd  --uid ${UID:-1000} --gid suwayomi --no-log-init suwayomi && \
     mkdir -p /home/suwayomi/.local/share/Tachidesk
 
 WORKDIR /home/suwayomi


### PR DESCRIPTION
Here is an updated Dockerfile to fix the permissions issue from the hardcoded UID and GID of 1000. Here it uses the default value of 1000 for both unless specified by environment variables. This is important for use with applications such as CasaOS or Home Assistant where you cannot specify permissions using the Docker user flag.