### PR TITLE
Support KCEF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,8 @@ EXPOSE 4567
 
 # Ubuntu exposes libgluegen_rt.so as libgluegen2_rt.so for some reason, so rename it
 # JCEF (or Java?) also does not search /usr/lib/jni, so copy them over into one it will search
-RUN mkdir -p natives/linux-amd64 && \
-    cp /usr/lib/jni/libgluegen2_rt.so natives/linux-amd64/libgluegen_rt.so && \
-    cp /usr/lib/jni/*.so natives/linux-amd64/
+RUN cp /usr/lib/jni/libgluegen2_rt.so libgluegen_rt.so && \
+    cp /usr/lib/jni/*.so ./
 
 CMD ["/home/suwayomi/startup_script.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,18 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# install CEF dependencies
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends -y libxss1 libxext6 libxrender1 libxcomposite1 libxdamage1 libxkbcommon0 libxtst6 \
+        libjogl2-jni libgluegen2-jni libglib2.0-0t64 libnss3 libdbus-1-3 libpango-1.0-0 libcairo2 libasound2t64 \
+        libatk-bridge2.0-0t64 libcups2t64 libdrm2 libgbm1 xvfb && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Create a user to run as
 RUN userdel -r ubuntu
 RUN groupadd --gid 1000 suwayomi && \
-    useradd  --uid 1000 --gid suwayomi --no-log-init suwayomi && \
+    useradd  --uid 1000 --gid suwayomi --no-log-init -G audio,video suwayomi && \
     mkdir -p /home/suwayomi/.local/share/Tachidesk
 
 WORKDIR /home/suwayomi
@@ -52,8 +60,18 @@ COPY scripts/startup_script.sh /home/suwayomi/startup_script.sh
 RUN chown -R suwayomi:suwayomi /home/suwayomi && \
     chmod 777 -R /home/suwayomi
 
+# must be created by root
+RUN mkdir /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+
 USER suwayomi
 EXPOSE 4567
+
+# Ubuntu exposes libgluegen_rt.so as libgluegen2_rt.so for some reason, so rename it
+# JCEF (or Java?) also does not search /usr/lib/jni, so copy them over into one it will search
+RUN mkdir -p natives/linux-amd64 && \
+    cp /usr/lib/jni/libgluegen2_rt.so natives/linux-amd64/libgluegen_rt.so && \
+    cp /usr/lib/jni/*.so natives/linux-amd64/
+
 CMD ["/home/suwayomi/startup_script.sh"]
 
 # vim: set ft=dockerfile:

--- a/scripts/startup_script.sh
+++ b/scripts/startup_script.sh
@@ -89,4 +89,6 @@ sed -i -r "s/server.opdsShowOnlyUnreadChapters = ([0-9]+|[a-zA-Z]+)( #)?/server.
 sed -i -r "s/server.opdsShowOnlyDownloadedChapters = ([0-9]+|[a-zA-Z]+)( #)?/server.opdsShowOnlyDownloadedChapters = ${OPDS_SHOW_ONLY_DOWNLOADED_CHAPTERS:-\1} #/" /home/suwayomi/.local/share/Tachidesk/server.conf
 sed -i -r "s/server.opdsChapterSortOrder = \"(.*?)\"( #)?/server.opdsChapterSortOrder = \"${OPDS_CHAPTER_SORT_ORDER:-\1}\" #/" /home/suwayomi/.local/share/Tachidesk/server.conf
 
+Xvfb :0 -screen 0 800x680x24 -nolisten tcp >/dev/null 2>&1 &
+export DISPLAY=:0
 exec java -Duser.home=/home/suwayomi -jar "/home/suwayomi/startup/tachidesk_latest.jar";


### PR DESCRIPTION
Install native dependencies required by JCEF
Sets up JNI libraries as required by the browser process
Launch Suwayomi in a XVFB environment to fake X11

For Suwayomi/Suwayomi-Server#1434