### PR TITLE
Merge builds again, use BUILDPLATFORM to decide KCEF

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -173,7 +173,7 @@ jobs:
         if: inputs.do_upload
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x,linux/riscv64
           push: true
           build-args: |
             BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
@@ -181,30 +181,7 @@ jobs:
             TACHIDESK_RELEASE_DOWNLOAD_URL=${{ steps.get_latest_release_metadata.outputs.release_url }}
             TACHIDESK_FILENAME=${{ steps.get_latest_release_metadata.outputs.release_filename }}
             TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
-          tags: |
-            ${{ inputs.tachidesk_release_type == 'stable' && 'ghcr.io/suwayomi/tachidesk:latest' || '' }}
-            ghcr.io/suwayomi/tachidesk:${{ inputs.tachidesk_release_type }}
-            ghcr.io/suwayomi/tachidesk:${{ steps.get_latest_release_metadata.outputs.release_tag }}
-            ${{ inputs.tachidesk_release_type == 'stable' && 'ghcr.io/suwayomi/suwayomi-server:latest' || '' }}
-            ghcr.io/suwayomi/suwayomi-server:${{ inputs.tachidesk_release_type }}
-            ghcr.io/suwayomi/suwayomi-server:${{ steps.get_latest_release_metadata.outputs.release_tag }}
-
-      # And also those that aren't supported by KCEF
-      # the build arg TACHIDESK_KCEF will simply not install the dependencies, so runtime will fail to load libs
-      # but everything else will still work
-      - name: Push container image to registry
-        if: inputs.do_upload
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/ppc64le,linux/s390x,linux/riscv64
-          push: true
-          build-args: |
-            BUILD_DATE=${{ steps.get_latest_release_metadata.outputs.build_date }}
-            TACHIDESK_RELEASE_TAG=${{ steps.get_latest_release_metadata.outputs.release_tag }}
-            TACHIDESK_RELEASE_DOWNLOAD_URL=${{ steps.get_latest_release_metadata.outputs.release_url }}
-            TACHIDESK_FILENAME=${{ steps.get_latest_release_metadata.outputs.release_filename }}
-            TACHIDESK_DOCKER_GIT_COMMIT=${{ steps.get_latest_release_metadata.outputs.tachidesk_docker_git_commit }}
-            TACHIDESK_KCEF=n
+            TACHIDESK_KCEF=
           tags: |
             ${{ inputs.tachidesk_release_type == 'stable' && 'ghcr.io/suwayomi/tachidesk:latest' || '' }}
             ghcr.io/suwayomi/tachidesk:${{ inputs.tachidesk_release_type }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:21.0.7_6-jre-noble
 
 ARG BUILD_DATE
-ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 ARG TACHIDESK_RELEASE_TAG
 ARG TACHIDESK_FILENAME
 ARG TACHIDESK_RELEASE_DOWNLOAD_URL
@@ -36,7 +36,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # install CEF dependencies
-RUN if [ "$TACHIDESK_KCEF" = "y" ] || ([ "$TACHIDESK_KCEF" = "" ] && ([ "$BUILDPLATFORM" = "linux/amd64" ] || [ "$BUILDPLATFORM" = "linux/arm64" ])); then \
+RUN if [ "$TACHIDESK_KCEF" = "y" ] || ([ "$TACHIDESK_KCEF" = "" ] && ([ "$TARGETPLATFORM" = "linux/amd64" ] || [ "$TARGETPLATFORM" = "linux/arm64" ])); then \
       apt-get update && \
       apt-get -y install --no-install-recommends -y libxss1 libxext6 libxrender1 libxcomposite1 libxdamage1 libxkbcommon0 libxtst6 \
           libjogl2-jni libgluegen2-jni libglib2.0-0t64 libnss3 libdbus-1-3 libpango-1.0-0 libcairo2 libasound2t64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM eclipse-temurin:21.0.7_6-jre-noble
 
 ARG BUILD_DATE
+ARG BUILDPLATFORM
 ARG TACHIDESK_RELEASE_TAG
 ARG TACHIDESK_FILENAME
 ARG TACHIDESK_RELEASE_DOWNLOAD_URL
 ARG TACHIDESK_DOCKER_GIT_COMMIT
-ARG TACHIDESK_KCEF=y # y or n
+ARG TACHIDESK_KCEF=y # y or n, leave empty for auto-detection
 
 LABEL maintainer="suwayomi" \
       org.opencontainers.image.title="Suwayomi Docker" \
@@ -35,9 +36,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # install CEF dependencies
-# Ubuntu exposes libgluegen_rt.so as libgluegen2_rt.so for some reason, so rename it
-# JCEF (or Java?) also does not search /usr/lib/jni, so copy them over into one it will search
-RUN if [ "$TACHIDESK_KCEF" = "y" ]; then \
+RUN if [ "$TACHIDESK_KCEF" = "y" ] || ([ "$TACHIDESK_KCEF" = "" ] && ([ "$BUILDPLATFORM" = "linux/amd64" ] || [ "$BUILDPLATFORM" = "linux/arm64" ])); then \
       apt-get update && \
       apt-get -y install --no-install-recommends -y libxss1 libxext6 libxrender1 libxcomposite1 libxdamage1 libxkbcommon0 libxtst6 \
           libjogl2-jni libgluegen2-jni libglib2.0-0t64 libnss3 libdbus-1-3 libpango-1.0-0 libcairo2 libasound2t64 \
@@ -68,7 +67,7 @@ RUN chown -R suwayomi:suwayomi /home/suwayomi && \
 # .X11-unix must be created by root
 # Ubuntu exposes libgluegen_rt.so as libgluegen2_rt.so for some reason, so rename it
 # JCEF (or Java?) also does not search /usr/lib/jni, so copy them over into one it will search
-RUN if [ "$TACHIDESK_KCEF" = "y" ]; then \
+RUN if command -v Xvfb; then \
       mkdir /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix && \
       cp /usr/lib/jni/libgluegen2_rt.so libgluegen_rt.so && \
       cp /usr/lib/jni/*.so ./; \
@@ -76,8 +75,6 @@ RUN if [ "$TACHIDESK_KCEF" = "y" ]; then \
 
 USER suwayomi
 EXPOSE 4567
-ENV TACHIDESK_KCEF=$TACHIDESK_KCEF
-
 
 CMD ["/home/suwayomi/startup_script.sh"]
 

--- a/scripts/startup_script.sh
+++ b/scripts/startup_script.sh
@@ -89,7 +89,7 @@ sed -i -r "s/server.opdsShowOnlyUnreadChapters = ([0-9]+|[a-zA-Z]+)( #)?/server.
 sed -i -r "s/server.opdsShowOnlyDownloadedChapters = ([0-9]+|[a-zA-Z]+)( #)?/server.opdsShowOnlyDownloadedChapters = ${OPDS_SHOW_ONLY_DOWNLOADED_CHAPTERS:-\1} #/" /home/suwayomi/.local/share/Tachidesk/server.conf
 sed -i -r "s/server.opdsChapterSortOrder = \"(.*?)\"( #)?/server.opdsChapterSortOrder = \"${OPDS_CHAPTER_SORT_ORDER:-\1}\" #/" /home/suwayomi/.local/share/Tachidesk/server.conf
 
-if [ "$TACHIDESK_KCEF" = "" ] || [ "$TACHIDESK_KCEF" = "y" ]; then
+if command -v Xvfb >/dev/null; then
   Xvfb :0 -screen 0 800x680x24 -nolisten tcp >/dev/null 2>&1 &
   export DISPLAY=:0
 else


### PR DESCRIPTION
I've left the TACHIDESK_KCEF argument to allow users to override. But if it is not set (i.e. the empty string), the build looks at BUILDPLATFORM to decide to include KCEF support or not.

I hope the platform for arm64 is correct, since you also include /v8, but GH CI logs suggest linux/arm64 should be right.