### PR TITLE
Fix: don't try to link KCEF when it's not downloaded

### DIFF
--- a/scripts/startup_script.sh
+++ b/scripts/startup_script.sh
@@ -93,11 +93,14 @@ if command -v Xvfb >/dev/null; then
   Xvfb :0 -screen 0 800x680x24 -nolisten tcp >/dev/null 2>&1 &
   export DISPLAY=:0
 
-  if [ ! -d /home/suwayomi/.local/share/Tachidesk/bin ]; then
-    mkdir -p /home/suwayomi/.local/share/Tachidesk/bin
-  fi
-  if [ ! -d /home/suwayomi/.local/share/Tachidesk/bin/kcef ] && [ ! -L /home/suwayomi/.local/share/Tachidesk/bin/kcef ]; then
-    ln -s /opt/kcef/jcef /home/suwayomi/.local/share/Tachidesk/bin/kcef
+  if [ -d /opt/kcef/jcef ]; then
+    # if we have KCEF downloaded in the container, attempt to link it into the data directory where Suwayomi expects it
+    if [ ! -d /home/suwayomi/.local/share/Tachidesk/bin ]; then
+      mkdir -p /home/suwayomi/.local/share/Tachidesk/bin
+    fi
+    if [ ! -d /home/suwayomi/.local/share/Tachidesk/bin/kcef ] && [ ! -L /home/suwayomi/.local/share/Tachidesk/bin/kcef ]; then
+      ln -s /opt/kcef/jcef /home/suwayomi/.local/share/Tachidesk/bin/kcef
+    fi
   fi
   export LD_PRELOAD=/home/suwayomi/.local/share/Tachidesk/bin/kcef/libcef.so
 else


### PR DESCRIPTION
Avoids this: https://github.com/Suwayomi/Suwayomi-Server/issues/1454#issuecomment-2993083015

When KCEF is not downloaded in the container, creating the directory or the symlink should not be done, otherwise KCEF will fail to download