### PR TITLE
Add warning on startup failure to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 Run [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server) inside docker container as non-root user. The server will be running on http://localhost:4567 open this url in your browser.
 
-> [!CAUTION]
-> This docker image is known to occasionally fail to work. This seems to be caused by problems in the download. If the logs simply end with `LD_PRELOAD=/opt/catch_abort.so /home/suwayomi/.local/share/Tachidesk/bin/kcef/libcef.so`, please remove the downloaded image and pull again. If this does not help, open a [new issue](https://github.com/Suwayomi/Suwayomi-Server-docker/issues/new).
-
 Docker Releases - https://github.com/Suwayomi/Suwayomi-Server-docker/pkgs/container/tachidesk
 
 Dockerfile - https://github.com/Suwayomi/Suwayomi-Server-docker
@@ -81,6 +78,10 @@ There are a number of environment variables available to configure Suwayomi:
 |   **OPDS_SHOW_ONLY_UNREAD_CHAPTERS**   |         `false`         |                                                                      Filter manga feed to display only chapters you haven't read                                                                      |
 | **OPDS_SHOW_ONLY_DOWNLOADED_CHAPTERS** |         `false`         |                                                                    Filter manga feed to display only chapters you have downloaded                                                                     |
 |      **OPDS_CHAPTER_SORT_ORDER**       |         `DESC`          |                                                                                            "DESC" or "ASC"                                                                                            |
+
+> [!CAUTION]
+> This docker image is known to occasionally fail to work. This seems to be caused by problems in the download. If the logs simply end with `LD_PRELOAD=/opt/catch_abort.so /home/suwayomi/.local/share/Tachidesk/bin/kcef/libcef.so`, please remove the downloaded image and pull again. If this does not help, open a [new issue](https://github.com/Suwayomi/Suwayomi-Server-docker/issues/new).
+
 
 ### Downloads Folder
 We do not allow configuration of the downloads folder, since Docker Volumes can handle that instead, here is an example of a docker-compose.yaml that has downloads volume configuration:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 Run [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server) inside docker container as non-root user. The server will be running on http://localhost:4567 open this url in your browser.
 
+> [!CAUTION]
+> This docker image is known to occasionally fail to work. This seems to be caused by problems in the download. If the logs simply end with `LD_PRELOAD=/opt/catch_abort.so /home/suwayomi/.local/share/Tachidesk/bin/kcef/libcef.so`, please remove the downloaded image and pull again. If this does not help, open a [new issue](https://github.com/Suwayomi/Suwayomi-Server-docker/issues/new).
+
 Docker Releases - https://github.com/Suwayomi/Suwayomi-Server-docker/pkgs/container/tachidesk
 
 Dockerfile - https://github.com/Suwayomi/Suwayomi-Server-docker


### PR DESCRIPTION
Since this happened two times now, let's assume this is not an isolated thing. I'm not sure how to even attempt to fix something like this; in both cases it was solved by downloading the image freshly, while restarting did not help. The image itself does not seem to have a problem, as it's not reproducible on other machines...