### PR TITLE
Improve image size and cachability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ ARG BUILD_DATE
 ARG TARGETPLATFORM
 ARG TACHIDESK_RELEASE_TAG
 ARG TACHIDESK_FILENAME
-ARG TACHIDESK_RELEASE_DOWNLOAD_URL
 ARG TACHIDESK_DOCKER_GIT_COMMIT
 ARG TACHIDESK_KCEF=y # y or n, leave empty for auto-detection
 ARG TACHIDESK_KCEF_RELEASE_URL
@@ -74,6 +73,7 @@ RUN groupadd --gid 1000 suwayomi && \
 WORKDIR /home/suwayomi
 
 # Copy the app into the container
+ARG TACHIDESK_RELEASE_DOWNLOAD_URL
 RUN curl -s --create-dirs -L $TACHIDESK_RELEASE_DOWNLOAD_URL -o /home/suwayomi/startup/tachidesk_latest.jar
 COPY scripts/create_server_conf.sh /home/suwayomi/create_server_conf.sh
 COPY scripts/startup_script.sh /home/suwayomi/startup_script.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,23 +46,14 @@ RUN if [ "$TACHIDESK_KCEF" = "y" ] || ([ "$TACHIDESK_KCEF" = "" ] && ([ "$TARGET
 COPY --from=build /opt/*.so /opt/
 
 # Create a user to run as
-RUN userdel -r ubuntu
-RUN groupadd --gid 1000 suwayomi && \
-    useradd  --uid 1000 --gid suwayomi --no-log-init -G audio,video suwayomi && \
-    mkdir -p /home/suwayomi/.local/share/Tachidesk
-
-WORKDIR /home/suwayomi
-
-# update permissions of files.
-# we grant o+rwx because we need to allow non default UIDs (eg via docker run ... --user)
-# to write to the directory to generate the server.conf
-RUN chown -R suwayomi:suwayomi /home/suwayomi && \
-    chmod 777 -R /home/suwayomi
-
 # .X11-unix must be created by root
 # Ubuntu exposes libgluegen_rt.so as libgluegen2_rt.so for some reason, so rename it
 # JCEF (or Java?) also does not search /usr/lib/jni, so copy them over into one it will search
-RUN if command -v Xvfb; then \
+RUN userdel -r ubuntu && \
+    groupadd --gid 1000 suwayomi && \
+    useradd  --uid 1000 --gid suwayomi --no-log-init -G audio,video suwayomi && \
+    mkdir -p /home/suwayomi/.local/share/Tachidesk && \
+    if command -v Xvfb; then \
       mkdir /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix && \
       cp /usr/lib/jni/libgluegen2_rt.so libgluegen_rt.so && \
       cp /usr/lib/jni/*.so ./; \
@@ -73,7 +64,12 @@ COPY scripts/startup_script.sh /home/suwayomi/startup_script.sh
 
 ARG TACHIDESK_RELEASE_DOWNLOAD_URL
 # Copy the app into the container
-RUN curl -s --create-dirs -L $TACHIDESK_RELEASE_DOWNLOAD_URL -o /home/suwayomi/startup/tachidesk_latest.jar
+# then update permissions of files.
+# we grant o+rwx because we need to allow non default UIDs (eg via docker run ... --user)
+# to write to the directory to generate the server.conf
+RUN curl -s --create-dirs -L $TACHIDESK_RELEASE_DOWNLOAD_URL -o /home/suwayomi/startup/tachidesk_latest.jar && \
+    chmod 777 -R /home/suwayomi && \
+    chown -R suwayomi:suwayomi /home/suwayomi
 
 ARG BUILD_DATE
 ARG TACHIDESK_RELEASE_TAG
@@ -95,6 +91,7 @@ LABEL maintainer="suwayomi" \
       org.opencontainers.image.licenses="MPL-2.0"
 
 ENV HOME=/home/suwayomi
+WORKDIR /home/suwayomi
 USER suwayomi
 EXPOSE 4567
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,14 +42,10 @@ LABEL maintainer="suwayomi" \
       org.opencontainers.image.licenses="MPL-2.0"
 
 # Install envsubst from GNU's gettext project
-RUN apt-get update && \
-    apt-get -y install gettext-base && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 # install unzip to unzip the server-reference.conf from the jar
+# Install tini for a tiny init system (handles orphan processes for graceful restart)
 RUN apt-get update && \
-    apt-get -y install -y unzip tini && \
+    apt-get -y install -y gettext-base unzip tini && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,28 +17,9 @@ RUN if [ -n "$TACHIDESK_ABORT_HANDLER_DOWNLOAD_URL" ]; then \
 
 FROM eclipse-temurin:21.0.8_9-jre-noble
 
-ARG BUILD_DATE
 ARG TARGETPLATFORM
-ARG TACHIDESK_RELEASE_TAG
-ARG TACHIDESK_FILENAME
-ARG TACHIDESK_DOCKER_GIT_COMMIT
 ARG TACHIDESK_KCEF=y # y or n, leave empty for auto-detection
 ARG TACHIDESK_KCEF_RELEASE_URL
-
-LABEL maintainer="suwayomi" \
-      org.opencontainers.image.title="Suwayomi Docker" \
-      org.opencontainers.image.authors="https://github.com/suwayomi" \
-      org.opencontainers.image.url="https://github.com/suwayomi/docker-tachidesk/pkgs/container/tachidesk" \
-      org.opencontainers.image.source="https://github.com/suwayomi/docker-tachidesk" \
-      org.opencontainers.image.description="This image is used to start suwayomi server in a container" \
-      org.opencontainers.image.vendor="suwayomi" \
-      org.opencontainers.image.created=$BUILD_DATE \
-      org.opencontainers.image.version=$TACHIDESK_RELEASE_TAG \
-      tachidesk.docker_commit=$TACHIDESK_DOCKER_GIT_COMMIT \
-      tachidesk.release_tag=$TACHIDESK_RELEASE_TAG \
-      tachidesk.filename=$TACHIDESK_FILENAME \
-      download_url=$TACHIDESK_RELEASE_DOWNLOAD_URL \
-      org.opencontainers.image.licenses="MPL-2.0"
 
 # Install envsubst from GNU's gettext project
 # install unzip to unzip the server-reference.conf from the jar
@@ -72,12 +53,6 @@ RUN groupadd --gid 1000 suwayomi && \
 
 WORKDIR /home/suwayomi
 
-# Copy the app into the container
-ARG TACHIDESK_RELEASE_DOWNLOAD_URL
-RUN curl -s --create-dirs -L $TACHIDESK_RELEASE_DOWNLOAD_URL -o /home/suwayomi/startup/tachidesk_latest.jar
-COPY scripts/create_server_conf.sh /home/suwayomi/create_server_conf.sh
-COPY scripts/startup_script.sh /home/suwayomi/startup_script.sh
-
 # update permissions of files.
 # we grant o+rwx because we need to allow non default UIDs (eg via docker run ... --user)
 # to write to the directory to generate the server.conf
@@ -92,6 +67,32 @@ RUN if command -v Xvfb; then \
       cp /usr/lib/jni/libgluegen2_rt.so libgluegen_rt.so && \
       cp /usr/lib/jni/*.so ./; \
     fi
+
+COPY scripts/create_server_conf.sh /home/suwayomi/create_server_conf.sh
+COPY scripts/startup_script.sh /home/suwayomi/startup_script.sh
+
+ARG TACHIDESK_RELEASE_DOWNLOAD_URL
+# Copy the app into the container
+RUN curl -s --create-dirs -L $TACHIDESK_RELEASE_DOWNLOAD_URL -o /home/suwayomi/startup/tachidesk_latest.jar
+
+ARG BUILD_DATE
+ARG TACHIDESK_RELEASE_TAG
+ARG TACHIDESK_FILENAME
+ARG TACHIDESK_DOCKER_GIT_COMMIT
+LABEL maintainer="suwayomi" \
+      org.opencontainers.image.title="Suwayomi Docker" \
+      org.opencontainers.image.authors="https://github.com/suwayomi" \
+      org.opencontainers.image.url="https://github.com/suwayomi/docker-tachidesk/pkgs/container/tachidesk" \
+      org.opencontainers.image.source="https://github.com/suwayomi/docker-tachidesk" \
+      org.opencontainers.image.description="This image is used to start suwayomi server in a container" \
+      org.opencontainers.image.vendor="suwayomi" \
+      org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.version=$TACHIDESK_RELEASE_TAG \
+      tachidesk.docker_commit=$TACHIDESK_DOCKER_GIT_COMMIT \
+      tachidesk.release_tag=$TACHIDESK_RELEASE_TAG \
+      tachidesk.filename=$TACHIDESK_FILENAME \
+      download_url=$TACHIDESK_RELEASE_DOWNLOAD_URL \
+      org.opencontainers.image.licenses="MPL-2.0"
 
 ENV HOME=/home/suwayomi
 USER suwayomi


### PR DESCRIPTION
- Merge some commands into one  
  This reduces the number of layers, which helps with the download.  
  In some cases, it also reduces size, e.g. having `chown` in a separate command means the files from previous layers are touched, effectively duplicating the contents (in this case the jar file is present fully in two layers).
- Move `ARG` directives as low as possible  
  `ARG`s taint every layer following, so having them at the end means all previous layers (including KCEF) are automatically cached. Previously, everything except the `build` image had to be rebuilt every time.

I hope these cache gains also translate to CI, I'm not sure how well that works if the image is built on a machine that doesn't have the cached layers yet (since CI starts blank). I think the hash should be the same, so the registry should pick up on that, but not entirely sure.

This improves total size (including JRE I think) from 1366.45 MB to 1184.843 MB (including KCEF) as reported by `docker image inspect`.