### PR TITLE
Attempt to get CI to cache layers

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -221,6 +221,8 @@ jobs:
             ${{ inputs.tachidesk_release_type == 'stable' && 'ghcr.io/suwayomi/suwayomi-server:latest' || '' }}
             ghcr.io/suwayomi/suwayomi-server:${{ inputs.tachidesk_release_type }}
             ghcr.io/suwayomi/suwayomi-server:${{ steps.get_latest_release_metadata.outputs.release_tag }}
+        env:
+          SOURCE_DATE_EPOCH: 0
 
       # - name: Create slim container
       #   uses: kitabisa/docker-slim-action@v1


### PR DESCRIPTION
While the image is now smaller than before, the CI build as-is still does not allow caching.

```
   ✔ 76249c7cd503 Already exists                                                                                                                                            0.0s 
   ✔ f706b5aed643 Already exists                                                                                                                                            0.0s 
   ✔ 929e753abe01 Already exists                                                                                                                                            0.0s 
   ✔ 9eb9a8044837 Already exists                                                                                                                                            0.0s 
   ✔ 5d5a1fad7028 Already exists                                                                                                                                            0.0s 
      // above should be the base image (temurin jre), below suwayomi
   ✔ cc2151cf62e3 Pull complete                                                                                                                                             1.1s 
   ✔ 3090a04e3f3e Pull complete                                                                                                                                             1.1s 
   ✔ c9da35efe191 Pull complete                                                                                                                                            53.5s 
   ✔ 70f0c4d17f0a Pull complete                                                                                                                                            53.5s 
   ✔ 5348b659f0d9 Pull complete                                                                                                                                            53.5s 
   ✔ 6ba039162d0a Pull complete                                                                                                                                            53.5s 
   ✔ 109ca5ff2728 Pull complete                                                                                                                                            53.6s 
   ✔ f62afffff278 Pull complete                                                                                                                                            54.6s 
   ✔ 4f4fb700ef54 Pull complete 
```

This attempts to make the layers cachable by making the build [reproducible](https://docs.docker.com/build/ci/github-actions/reproducible-builds/).

If this doesn't work, [manual caching during build](https://docs.docker.com/build/ci/github-actions/cache/#registry-cache) may be necessary, though I think it's preferrable to avoid that.