### PR TITLE
Fix retrieval of DATABASE_PASSWORD_FILE secret value in startup script

### DIFF
--- a/scripts/startup_script.sh
+++ b/scripts/startup_script.sh
@@ -22,7 +22,7 @@ if [ -f "${BASIC_AUTH_PASSWORD_FILE}" ]; then
     export BASIC_AUTH_PASSWORD=$(cat "${BASIC_AUTH_PASSWORD_FILE}")
 fi
 if [ -f "${DATABASE_PASSWORD_FILE}" ]; then
-    export DATABASE_PASSWORD=$(cat "${DATABSE_PASSWORD_FILE}")
+    export DATABASE_PASSWORD=$(cat "${DATABASE_PASSWORD_FILE}")
 fi
 if [ -f "${SYNCYOMI_API_KEY_FILE}" ]; then
     export SYNCYOMI_API_KEY=$(cat "${SYNCYOMI_API_KEY_FILE}")


### PR DESCRIPTION
The typo caused the password to be set to an empty string, preventing Suwayomi from starting when configured to use Postgres.

Fixes #242.